### PR TITLE
Remove specific Qt Framework version from the manpage

### DIFF
--- a/man/smplayer.1
+++ b/man/smplayer.1
@@ -10,7 +10,7 @@ SMPlayer \- The best GUI frontend for MPlayer
 [\fI\-help|\-\-help|\-h|\-?\fR] [\fI<media1>\fR] [\fI<media2>\fR]...
 .SH DESCRIPTION
 .TP
-SMPlayer is a GUI media player based on Qt 4, using \fBmplayer\fR(1) as its backend.
+SMPlayer is a GUI media player based on Qt, using \fBmplayer\fR(1) as its backend.
 .SH OPTIONS
 .TP
 .B \-minigui


### PR DESCRIPTION
There's not much reason to keep the Qt version in.

The manpage had the incorrect version(4) for nearly a decade at this point I believe, dropping it avoids the mistake whenever the framework version gets bumped again.