### PR TITLE
Prefer the x11egl gpu-context over x11 for mpv

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1755,7 +1755,7 @@ void Core::startMplayer( QString file, double seek ) {
 		}
 		if (proc->isMPV()) {
 			if (pref->vo.startsWith("gpu")) {
-				proc->setOption("gpu-context", "x11");
+				proc->setOption("gpu-context", "x11egl");
 			}
 		}
 	}


### PR DESCRIPTION
The x11 context is outdated and VAAPI doesn't work with it.