### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/install_appdata.sh
+++ b/install_appdata.sh
@@ -2,6 +2,9 @@
 install -m 644 smplayer.appdata.xml $1
 
 ./get_version.sh
+DATE_FMT="+%Y-%m-%d"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+DATE=`date -u -d "@$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u "$DATE_FMT"`
 sed -i -e "s/{version}/`cat version`/" $1
-sed -i -e "s/{date}/`date +%Y-%m-%d`/" $1
+sed -i -e "s/{date}/$DATE/" $1
 


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call works with many variants of date.
Also use `-u` (UTC) to be independent of timezone.

An alternative approach would be to drop the date here.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).