### PR TITLE
Add secondarySubVisibilityAct

### DIFF
--- a/src/basegui.cpp
+++ b/src/basegui.cpp
@@ -866,6 +866,12 @@ void BaseGui::createActions() {
 	subVisibilityAct->setCheckable(true);
 	connect( subVisibilityAct, SIGNAL(toggled(bool)), core, SLOT(changeSubVisibility(bool)) );
 
+#ifdef MPV_SUPPORT
+	secondarySubVisibilityAct = new MyAction(this, "secondary_sub_visibility");
+	secondarySubVisibilityAct->setCheckable(true);
+	connect( secondarySubVisibilityAct, SIGNAL(toggled(bool)), core, SLOT(changeSecondarySubVisibility(bool)) );
+#endif
+
 #ifdef FIND_SUBTITLES
 	showFindSubtitlesDialogAct = new MyAction( this, "show_find_sub_dialog" );
 	connect( showFindSubtitlesDialogAct, SIGNAL(triggered()), 

--- a/src/basegui.h
+++ b/src/basegui.h
@@ -559,6 +559,9 @@ protected:
 	MyAction * useCustomSubStyleAct;
 	MyAction * useForcedSubsOnlyAct;
 	MyAction * subVisibilityAct;
+#ifdef MPV_SUPPORT
+	MyAction * secondarySubVisibilityAct;
+#endif
 #ifdef FIND_SUBTITLES
 	MyAction * showFindSubtitlesDialogAct;
 	MyAction * openUploadSubtitlesPageAct;//turbos  

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -3686,6 +3686,17 @@ void Core::changeSubVisibility(bool visible) {
 		displayMessage( tr("Subtitles off") );
 }
 
+#ifdef MPV_SUPPORT
+void Core::changeSecondarySubVisibility(bool visible) {
+	qDebug("Core::changeSecondarySubVisibility: %d", visible);
+	pref->secondary_sub_visibility = visible;
+
+	if (proc->isRunning()) {
+		proc->setSecondarySubtitlesVisibility(pref->secondary_sub_visibility);
+	}
+}
+#endif
+
 void Core::changeExternalSubFPS(int fps_id) {
 	qDebug("Core::setExternalSubFPS: %d", fps_id);
 	mset.external_subtitles_fps = fps_id;

--- a/src/core.h
+++ b/src/core.h
@@ -273,8 +273,10 @@ public slots:
 	void incSubStep();
 	//! Select previous line in subtitle file
 	void decSubStep();
-
 	void changeSubVisibility(bool visible);
+#ifdef MPV_SUPPORT
+	void changeSecondarySubVisibility(bool visible);
+#endif
 
 	void changeExternalSubFPS(int fps_id);
 

--- a/src/mplayeroptions.cpp
+++ b/src/mplayeroptions.cpp
@@ -411,6 +411,13 @@ void MplayerProcess::setSubtitlesVisibility(bool b) {
 	sendCommand(QString("sub_visibility %1").arg(b ? 1 : 0));
 }
 
+#ifdef MPV_SUPPORT
+void MplayerProcess::setSecondarySubtitlesVisibility(bool /*value*/) {
+	/* Not supported */
+	showOSDText(tr("This option is not supported by MPlayer"), 3000, 1);
+};
+#endif
+
 void MplayerProcess::seek(double secs, int mode, bool precise) {
 	QString s = QString("seek %1 %2").arg(secs).arg(mode);
 	if (precise) s += " 1"; else s += " -1";

--- a/src/mplayerprocess.h
+++ b/src/mplayerprocess.h
@@ -61,6 +61,9 @@ public:
 	void setSecondarySubtitle(int /*ID*/) {};
 	void disableSecondarySubtitles() {};
 	void setSubtitlesVisibility(bool b);
+#ifdef MPV_SUPPORT
+	void setSecondarySubtitlesVisibility(bool /*b*/);
+#endif
 	void seek(double secs, int mode, bool precise);
 	void mute(bool b);
 	void setPause(bool b);

--- a/src/mpvoptions.cpp
+++ b/src/mpvoptions.cpp
@@ -831,6 +831,10 @@ void MPVProcess::setSubtitlesVisibility(bool b) {
 	sendCommand(QString("no-osd set sub-visibility %1").arg(b ? "yes" : "no"));
 }
 
+void MPVProcess::setSecondarySubtitlesVisibility(bool b) {
+	sendCommand(QString("no-osd set secondary-sub-visibility %1").arg(b ? "yes" : "no"));
+}
+
 void MPVProcess::seek(double secs, int mode, bool precise) {
 	QString s = "seek " + QString::number(secs) + " ";
 	switch (mode) {

--- a/src/mpvprocess.h
+++ b/src/mpvprocess.h
@@ -87,6 +87,7 @@ public:
 	void setSecondarySubtitle(int ID);
 	void disableSecondarySubtitles();
 	void setSubtitlesVisibility(bool b);
+	void setSecondarySubtitlesVisibility(bool b);
 	void seek(double secs, int mode, bool precise);
 	void mute(bool b);
 	void setPause(bool b);

--- a/src/playerprocess.h
+++ b/src/playerprocess.h
@@ -69,6 +69,9 @@ public:
 	virtual void setSecondarySubtitle(int ID) = 0;
 	virtual void disableSecondarySubtitles() = 0;
 	virtual void setSubtitlesVisibility(bool b) = 0;
+#ifdef MPV_SUPPORT
+	virtual void setSecondarySubtitlesVisibility(bool b) = 0;
+#endif	
 	virtual void seek(double secs, int mode, bool precise) = 0;
 	virtual void mute(bool b) = 0;
 	virtual void setPause(bool b) = 0;

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -252,6 +252,9 @@ public:
 	bool use_forced_subs_only;
 
 	bool sub_visibility;
+#ifdef MPV_SUPPORT
+	bool secondary_sub_visibility;
+#endif
 
 	bool subtitles_on_screenshots;
 


### PR DESCRIPTION
Add action for MPV's secondary-sub-visibility option.
So you could enable/disable secondary subtitle with a hotkey.