### PR TITLE
Disable the screensaver only when playing video.

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -269,7 +269,6 @@ Core::Core( MplayerWindow *mpw, QWidget* parent )
 
 #ifdef SCREENSAVER_OFF
 	screensaver = new ScreenSaver(this);
-	connect( this, SIGNAL(aboutToStartPlaying()), this, SLOT(disableScreensaver()) );
 	connect( proc, SIGNAL(processExited()), this, SLOT(enableScreensaver()) );
 	connect( proc, SIGNAL(error(QProcess::ProcessError)), this, SLOT(enableScreensaver()) );
 #endif
@@ -4760,16 +4759,13 @@ void Core::sendMediaInfo() {
 //!  Called when the state changes
 void Core::watchState(Core::State state) {
 #ifdef SCREENSAVER_OFF
-	#if 0
 	qDebug("Core::watchState: %d", state);
-	//qDebug("Core::watchState: has video: %d", !mdat.novideo);
 
-	if ((state == Playing) /* && (!mdat.novideo) */) {
+	if (state == Playing) {
 		disableScreensaver();
 	} else {
 		enableScreensaver();
 	}
-	#endif
 #endif
 
 	if ((proc->isMPlayer()) && (state == Playing) && (change_volume_after_unpause)) {


### PR DESCRIPTION
It is entirely possible that this functionality isn't desired; it looks like it was implemented at some point, then disabled in 9713cfd. I do not know if this will break things in Windows again - from looking at it code, it shouldn't, but maybe there's a bug? This is also arguably a breaking change because there is no longer a "disable screensaver even when not playing video" option.

I'd really like an option to accomplish this, however, and I'm happy to keep working on it as requested. If you'd like further testing, let me know! And if you'd prefer a different design, possibly a "Don't Disable Screensaver/Disable Screensaver When Playing/Disable Screensaver Always" dropdown, tell me the design that you'd like and I'll put that together :)