### PR TITLE
set Qt::AA_UseHighDpiPixmaps attribute

### DIFF
--- a/src/hdpisupport.cpp
+++ b/src/hdpisupport.cpp
@@ -141,6 +141,7 @@ void HDPISupport::apply() {
 		if (!auto_scale) {
 			qputenv("QT_SCALE_FACTOR", QByteArray::number(scale_factor));
 		}
+		QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 		#endif
 	}
 }


### PR DESCRIPTION
this allows to display not blurred icons on HighDPI screens if pixmap resolution in the skin is big enough

before:
![Screenshot_20230309_212358](https://user-images.githubusercontent.com/947647/224149431-1076bcab-c966-43c1-8a84-740c5688b6b8.png)
after:
![Screenshot_20230309_212549](https://user-images.githubusercontent.com/947647/224149478-c2ddebf2-4d98-4b54-bdaa-e3f4173bdef4.png)
difference in menus is even more noticeable, but I found now way to get screenshot of it