### PR TITLE
bugfix for Issue #678 (Status bar millisecond time is wrong)

### DIFF
--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -81,14 +81,14 @@ QString Helper::formatTime2(double secs) {
 	bool negative = (secs < 0);
 	secs = qAbs(secs);
 
-	double t = secs;
+	double t = secs + 0.00049999; // add <0.5 ms to round to nearest millisecond, display otherwise sometimes shows 0.499 instead of 0.5
 	int hours = (int) t / 3600;
 	t -= hours*3600;
 	int minutes = (int) t / 60;
 	t -= minutes*60;
 	int seconds = t;
 	t -= seconds;
-	int milliseconds = (t*1000 + 0.4999);
+	int milliseconds = t*1000;
 
 	//qDebug() << "Helper::formatTime: secs:" << secs << "="  << hours << ":" << minutes << ":" << seconds << "." << milliseconds;
 

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -88,7 +88,7 @@ QString Helper::formatTime2(double secs) {
 	t -= minutes*60;
 	int seconds = t;
 	t -= seconds;
-	int milliseconds = t*1000;
+	int milliseconds = (t*1000 + 0.4999);
 
 	//qDebug() << "Helper::formatTime: secs:" << secs << "="  << hours << ":" << minutes << ":" << seconds << "." << milliseconds;
 

--- a/src/mpvprocess.cpp
+++ b/src/mpvprocess.cpp
@@ -264,6 +264,10 @@ void MPVProcess::parseLine(QByteArray ba) {
 		}
 
 		if (paused) {
+			if (last_sec != sec) {
+				last_sec = sec;
+				emit receivedCurrentSec(sec);
+			}
 			notified_pause = true;
 			qDebug("MPVProcess::parseLine: paused");
 			emit receivedPause();


### PR DESCRIPTION
Status bar millisecond display is one frame behind. The issue is that the player briefly leaves paused state and reenters it for single stepping - but a time-change that comes simultaneous with a new pause is not emitted.

Also fixes rounding error in status bar time display. ( 6.499 instead of 6.5) by adding 0.49999 milliseconds before int()-ing