### PR TITLE
Grab video seeker and volume slider by clicking and dragging anywhere on the slider bar

### DIFF
--- a/src/myslider.cpp
+++ b/src/myslider.cpp
@@ -108,15 +108,13 @@ void MySlider::mousePressEvent( QMouseEvent * e ) {
         const QPoint center = sliderRect.center() - sliderRect.topLeft();
         // to take half of the slider off for the setSliderPosition call we use the center - topLeft
 
-        if (!sliderRect.contains(e->pos())) {
-            e->accept();
+        setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
+        triggerAction(SliderMove);
+        setRepeatAction(SliderNoAction);
 
-            setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
-            triggerAction(SliderMove);
-            setRepeatAction(SliderNoAction);
-        } else {
-            QSlider::mousePressEvent(e);
-		}
+        // Propagating the event allows the user to keep holding
+        // down the mouse button and move the mouse to keep seeking.
+        QSlider::mousePressEvent(e);
 	} else {
 		QSlider::mousePressEvent(e);
 	}

--- a/src/skingui/panelseeker.cpp
+++ b/src/skingui/panelseeker.cpp
@@ -117,23 +117,20 @@ void PanelSeeker::mousePressEvent(QMouseEvent *m)
         #else
         QPointF pos = m->posF();
         #endif
-        if(knobRect.contains(pos))
-        {
-            isPressed = true;
-            mousePressPos = pos;
-            mousePressDifference = pos.x() - knobRect.center().x();
-            setSliderDown(true);
-            setState(Pressed, true);
-        }
-        else
-        {
-            isPressed = false;
-            #if QT_VERSION >= 0x050000
-            knobAdjust( m->localPos().x() - knobRect.center().x(), true);
-            #else
-            knobAdjust( m->posF().x() - knobRect.center().x(), true);
-            #endif
-        }
+
+        #if QT_VERSION >= 0x050000
+        knobAdjust( m->localPos().x() - knobRect.center().x(), true);
+        #else
+        knobAdjust( m->posF().x() - knobRect.center().x(), true);
+        #endif
+
+        // Putting the slider into pressed state allows the user to keep
+        // holding down the mouse button and move the mouse to keep seeking.
+        isPressed = true;
+        mousePressPos = pos;
+        mousePressDifference = pos.x() - knobRect.center().x();
+        setSliderDown(true);
+        setState(Pressed, true);
     }
 }
 


### PR DESCRIPTION
Fixes #687. Fixes #504 partially.

**Current behavior**: If you click on the video seeker bar anywhere outside the knob, the knob will jump to that point, but it is not possible to keep the left mouse button pressed and drag the knob 

**New behavior**: If you click on the video seeker bar anywhere outside the knob, the knob will jump to that point and it is possible to continue dragging it further forwards or backwards when keeping the left mouse button pressed.

The same applies to volume sliders which share the same code. The fix applies to both default GUI and skinned GUI to keep behaviors consistent.

This behavior massively increases ergonomics and is in line with almost all video/multimedia players like YouTube, VLC Media Player, foobar2000 and more.
