### PR TITLE
Re-add 'seek by clicking anywhere' to timeline slider. Fix and improve seeker behavior.

### DIFF
--- a/src/myslider.cpp
+++ b/src/myslider.cpp
@@ -105,15 +105,13 @@ void MySlider::mousePressEvent( QMouseEvent * e ) {
 		const QPoint center = sliderRect.center() - sliderRect.topLeft();
 		// to take half of the slider off for the setSliderPosition call we use the center - topLeft
 
-		if (!sliderRect.contains(e->pos())) {
-			e->accept();
+		setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
+		triggerAction(SliderMove);
+		setRepeatAction(SliderNoAction);
 
-			setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
-			triggerAction(SliderMove);
-			setRepeatAction(SliderNoAction);
-		} else {
-			QSlider::mousePressEvent(e);
-		}
+		// Propagating the event allows the user to keep holding
+		// down the mouse button and move the mouse to keep seeking.
+		QSlider::mousePressEvent(e);
 	} else {
 		QSlider::mousePressEvent(e);
 	}

--- a/src/myslider.cpp
+++ b/src/myslider.cpp
@@ -34,8 +34,7 @@
 #endif
 
 
-MySlider::MySlider( QWidget * parent ) : QSlider(parent)
-{
+MySlider::MySlider( QWidget * parent ) : QSlider(parent) {
 	setOrientation( Qt::Horizontal );
 }
 
@@ -44,78 +43,76 @@ MySlider::~MySlider() {
 
 #if CODE_FOR_CLICK == 1
 // Function copied from qslider.cpp
-inline int MySlider::pick(const QPoint &pt) const
-{
-    return orientation() == Qt::Horizontal ? pt.x() : pt.y();
+inline int MySlider::pick(const QPoint &pt) const {
+	return orientation() == Qt::Horizontal ? pt.x() : pt.y();
 }
 
 #if QT_VERSION < 0x040300
 // Function copied from qslider.cpp and modified to make it compile
-void MySlider::initStyleOption(QStyleOptionSlider *option) const
-{
-    if (!option)
-        return;
+void MySlider::initStyleOption(QStyleOptionSlider *option) const {
+	if (!option)
+		return;
 
-    option->initFrom(this);
-    option->subControls = QStyle::SC_None;
-    option->activeSubControls = QStyle::SC_None;
-    option->orientation = orientation();
-    option->maximum = maximum();
-    option->minimum = minimum();
-    option->tickPosition = (QSlider::TickPosition) tickPosition();
-    option->tickInterval = tickInterval();
-    option->upsideDown = (orientation() == Qt::Horizontal) ?
-                     (invertedAppearance() != (option->direction == Qt::RightToLeft))
-                     : (!invertedAppearance());
-    option->direction = Qt::LeftToRight; // we use the upsideDown option instead
-    option->sliderPosition = sliderPosition();
-    option->sliderValue = value();
-    option->singleStep = singleStep();
-    option->pageStep = pageStep();
-    if (orientation() == Qt::Horizontal)
-        option->state |= QStyle::State_Horizontal;
+	option->initFrom(this);
+	option->subControls = QStyle::SC_None;
+	option->activeSubControls = QStyle::SC_None;
+	option->orientation = orientation();
+	option->maximum = maximum();
+	option->minimum = minimum();
+	option->tickPosition = (QSlider::TickPosition) tickPosition();
+	option->tickInterval = tickInterval();
+	option->upsideDown = (orientation() == Qt::Horizontal) ?
+		(invertedAppearance() != (option->direction == Qt::RightToLeft))
+		: (!invertedAppearance());
+	option->direction = Qt::LeftToRight; // we use the upsideDown option instead
+	option->sliderPosition = sliderPosition();
+	option->sliderValue = value();
+	option->singleStep = singleStep();
+	option->pageStep = pageStep();
+	if (orientation() == Qt::Horizontal)
+		option->state |= QStyle::State_Horizontal;
 }
 #endif
 
 // Function copied from qslider.cpp and modified to make it compile
-int MySlider::pixelPosToRangeValue(int pos) const
-{
-    QStyleOptionSlider opt;
-    initStyleOption(&opt);
-    QRect gr = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderGroove, this);
-    QRect sr = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
-    int sliderMin, sliderMax, sliderLength;
+int MySlider::pixelPosToRangeValue(int pos) const {
+	QStyleOptionSlider opt;
+	initStyleOption(&opt);
+	QRect gr = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderGroove, this);
+	QRect sr = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+	int sliderMin, sliderMax, sliderLength;
 
-    if (orientation() == Qt::Horizontal) {
-        sliderLength = sr.width();
-        sliderMin = gr.x();
-        sliderMax = gr.right() - sliderLength + 1;
-    } else {
-        sliderLength = sr.height();
-        sliderMin = gr.y();
-        sliderMax = gr.bottom() - sliderLength + 1;
-    }
-    return QStyle::sliderValueFromPosition(minimum(), maximum(), pos - sliderMin,
-                                           sliderMax - sliderMin, opt.upsideDown);
+	if (orientation() == Qt::Horizontal) {
+		sliderLength = sr.width();
+		sliderMin = gr.x();
+		sliderMax = gr.right() - sliderLength + 1;
+	} else {
+		sliderLength = sr.height();
+		sliderMin = gr.y();
+		sliderMax = gr.bottom() - sliderLength + 1;
+	}
+	return QStyle::sliderValueFromPosition(
+		minimum(), maximum(), pos - sliderMin,
+		sliderMax - sliderMin, opt.upsideDown);
 }
 
 // Based on code from qslider.cpp
 void MySlider::mousePressEvent( QMouseEvent * e ) {
 	if (e->button() == Qt::LeftButton) {
-        QStyleOptionSlider opt;
-        initStyleOption(&opt);
-        const QRect sliderRect = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
-        const QPoint center = sliderRect.center() - sliderRect.topLeft();
-        // to take half of the slider off for the setSliderPosition call we use the center - topLeft
+		QStyleOptionSlider opt;
+		initStyleOption(&opt);
+		const QRect sliderRect = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+		const QPoint center = sliderRect.center() - sliderRect.topLeft();
+		// to take half of the slider off for the setSliderPosition call we use the center - topLeft
 
-        if (!sliderRect.contains(e->pos())) {
-            e->accept();
+		if (!sliderRect.contains(e->pos())) {
+			e->accept();
 
-            setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
-            triggerAction(SliderMove);
-            setRepeatAction(SliderNoAction);
-        } else {
-            QSlider::mousePressEvent(e);
+			setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
+			triggerAction(SliderMove);
+			setRepeatAction(SliderNoAction);
+		} else {
+			QSlider::mousePressEvent(e);
 		}
 	} else {
 		QSlider::mousePressEvent(e);

--- a/src/timeslider.cpp
+++ b/src/timeslider.cpp
@@ -18,12 +18,16 @@
 
 #include "timeslider.h"
 #include "helper.h"
+#include "global.h"
+#include "preferences.h"
 
 #include <QWheelEvent>
 #include <QTimer>
 #include <QToolTip>
 #include <QStyleOption>
 #include <QDebug>
+
+using Global::pref;
 
 #define DEBUG 0
 
@@ -79,7 +83,14 @@ void TimeSlider::sliderReleased_slot() {
 		// moved during mouse drag. Otherwise, on mouse release,
 		// we would spuriously seek to the same position we are in,
 		// causing seeker judder and video jitter during playback.
-		emit posChanged( value() );
+		if (!pref->update_while_seeking) {
+			// It only makes sense to emit a video seek action when
+			// "Seek to position when released" is active. When we
+			// "Seek to position while dragging", this event is
+			// spurious and should be skipped because the desired
+			// video seeking was already done when the slider moved.
+			emit posChanged( value() );
+		}
 	}
 	start_drag_pos = -1;
 	slider_has_moved = false;

--- a/src/timeslider.cpp
+++ b/src/timeslider.cpp
@@ -42,9 +42,8 @@ TimeSlider::TimeSlider( QWidget * parent ) : MySlider(parent)
 	setFocusPolicy( Qt::NoFocus );
 	setSizePolicy( QSizePolicy::Expanding , QSizePolicy::Fixed );
 
-	connect( this, SIGNAL( sliderPressed() ), this, SLOT( stopUpdate() ) );
-	connect( this, SIGNAL( sliderReleased() ), this, SLOT( resumeUpdate() ) );
-	connect( this, SIGNAL( sliderReleased() ), this, SLOT( mouseReleased() ) );
+	connect( this, SIGNAL( sliderPressed() ), this, SLOT( sliderPressed_slot() ) );
+	connect( this, SIGNAL( sliderReleased() ), this, SLOT( sliderReleased_slot() ) );
 	connect( this, SIGNAL( valueChanged(int) ), this, SLOT( valueChanged_slot(int) ) );
 #if ENABLE_DELAYED_DRAGGING
 	connect( this, SIGNAL(draggingPos(int) ), this, SLOT(checkDragging(int)) );
@@ -59,24 +58,18 @@ TimeSlider::TimeSlider( QWidget * parent ) : MySlider(parent)
 TimeSlider::~TimeSlider() {
 }
 
-void TimeSlider::stopUpdate() {
+void TimeSlider::sliderPressed_slot() {
 	#if DEBUG
-	qDebug("TimeSlider::stopUpdate");
+	qDebug("TimeSlider::sliderPressed_slot");
 	#endif
 	dont_update = true;
 }
 
-void TimeSlider::resumeUpdate() {
+void TimeSlider::sliderReleased_slot() {
 	#if DEBUG
-	qDebug("TimeSlider::resumeUpdate");
+	qDebug("TimeSlider::sliderReleased_slot");
 	#endif
 	dont_update = false;
-}
-
-void TimeSlider::mouseReleased() {
-	#if DEBUG
-	qDebug("TimeSlider::mouseReleased");
-	#endif
 	emit posChanged( value() );
 }
 

--- a/src/timeslider.h
+++ b/src/timeslider.h
@@ -66,6 +66,8 @@ protected:
 private:
 	bool dont_update;
 	int position;
+	int start_drag_pos;
+	bool slider_has_moved;
 	double total_time;
 
 #if ENABLE_DELAYED_DRAGGING

--- a/src/timeslider.h
+++ b/src/timeslider.h
@@ -51,9 +51,8 @@ signals:
 	void wheelDown();
 
 protected slots:
-	void stopUpdate();
-	void resumeUpdate();
-	void mouseReleased();
+	void sliderPressed_slot();
+	void sliderReleased_slot();
 	void valueChanged_slot(int);
 #if ENABLE_DELAYED_DRAGGING
 	void checkDragging(int);


### PR DESCRIPTION
This PR is the direct result of discussion #753. PR #692 had to be partially reverted due to a small video jitter caused when the timeline bar was clicked. This PR seeks to re-add the feature with fixes that solve this problem and further improve the seeker bar behavior.

- Re-add 'seek by clicking anywhere' on the timeline slider for the default/basic GUI.
- No longer cause spurious seek operation on mouse release when the slider hasn't been moved during a mouse drag on the slider
- No longer cause spurious seek operation on mouse release unless "Seek to position when released" is active
- Format `myslider.cpp`  as its indentation had mixed spaces and tabs

I initially underestimated the complexity involved in the seeker logic. This time, I scrutinized the code more closely and tested the changes more. I hope it no longer exhibits behaviors that bother the users.