### PR TITLE
Do not move slider when starting to drag by clicking on the slider

### DIFF
--- a/src/myslider.cpp
+++ b/src/myslider.cpp
@@ -105,9 +105,14 @@ void MySlider::mousePressEvent( QMouseEvent * e ) {
 		const QPoint center = sliderRect.center() - sliderRect.topLeft();
 		// to take half of the slider off for the setSliderPosition call we use the center - topLeft
 
-		setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
-		triggerAction(SliderMove);
-		setRepeatAction(SliderNoAction);
+		if (!sliderRect.contains(e->pos())) {
+			// Only move slider to mouse position if user didn't click
+			// on the slider. E.g. user clicked on a blank space on the
+			// timeline bar to seek to that time in the video.
+			setSliderPosition(pixelPosToRangeValue(pick(e->pos() - center)));
+			triggerAction(SliderMove);
+			setRepeatAction(SliderNoAction);
+		}
 
 		// Propagating the event allows the user to keep holding
 		// down the mouse button and move the mouse to keep seeking.

--- a/src/skingui/panelseeker.cpp
+++ b/src/skingui/panelseeker.cpp
@@ -118,11 +118,16 @@ void PanelSeeker::mousePressEvent(QMouseEvent *m)
         QPointF pos = m->posF();
         #endif
 
-        #if QT_VERSION >= 0x050000
-        knobAdjust( m->localPos().x() - knobRect.center().x(), true);
-        #else
-        knobAdjust( m->posF().x() - knobRect.center().x(), true);
-        #endif
+        if (!knobRect.contains(pos)) {
+            // Only move slider to mouse position if user didn't click
+            // on the slider. E.g. user clicked on a blank space on the
+            // timeline bar to seek to that time in the video.
+            #if QT_VERSION >= 0x050000
+            knobAdjust( m->localPos().x() - knobRect.center().x(), true);
+            #else
+            knobAdjust( m->posF().x() - knobRect.center().x(), true);
+            #endif
+        }
 
         // Putting the slider into pressed state allows the user to keep
         // holding down the mouse button and move the mouse to keep seeking.


### PR DESCRIPTION
A minor fix to the slider implementation, as discussed in #753. Works for both Basic (default) GUI and Skinned GUI.

When you click on the slider to start dragging it, it shouldn't perform an initial seek operation at all. It should only perform a seek operation when you click anywhere _except_ the slider on the timeline bar.
