### PR TITLE
Add a fallback to let mplayer control the screensaver

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1851,7 +1851,11 @@ void Core::startMplayer( QString file, double seek ) {
 	#ifndef USE_POWERSAVING
 	proc->setOption("stop-xscreensaver", pref->disable_screensaver);
 	#else
-	proc->setOption("stop-xscreensaver", false);
+	if (screensaver->isValid()) {
+	    proc->setOption("stop-xscreensaver", false);
+	} else { // fallback to let mplayer control the screensaver
+	    proc->setOption("stop-xscreensaver", pref->disable_screensaver);
+	}
 	#endif
 #endif
 

--- a/src/mplayeroptions.cpp
+++ b/src/mplayeroptions.cpp
@@ -135,8 +135,10 @@ void MplayerProcess::setOption(const QString & option_name, const QVariant & val
 	}
 	else
 	if (option_name == "stop-xscreensaver") {
+#ifdef OS_UNIX_NOT_MAC
 		bool stop_ss = value.toBool();
 		if (stop_ss) arg << "-stop-xscreensaver"; else arg << "-nostop-xscreensaver";
+#endif
 	}
 	else
 	if (option_name == "correct-pts") {

--- a/src/powersaving.cpp
+++ b/src/powersaving.cpp
@@ -37,6 +37,10 @@ PowerSaving::PowerSaving(QObject * parent)
 PowerSaving::~PowerSaving() {
 }
 
+bool PowerSaving::isValid() {
+    return interface->isValid();
+}
+
 void PowerSaving::inhibit() {
 	qDebug("PowerSaving::inhibit");
 	QDBusReply<uint> reply = interface->call("Inhibit", "smplayer", "Playing media");

--- a/src/powersaving.h
+++ b/src/powersaving.h
@@ -32,6 +32,8 @@ public:
 	PowerSaving(QObject * parent = 0);
 	~PowerSaving();
 
+	bool isValid();
+
 public slots:
 	void inhibit();
 	void uninhibit();

--- a/src/powersaving_mac.cpp
+++ b/src/powersaving_mac.cpp
@@ -29,6 +29,10 @@ PowerSaving::PowerSaving(QObject * parent)
 PowerSaving::~PowerSaving() {
 }
 
+bool PowerSaving::isValid() {
+	return true;
+}
+
 void PowerSaving::inhibit() {
 	qDebug("PowerSaving::inhibit");
 

--- a/src/powersaving_mac.h
+++ b/src/powersaving_mac.h
@@ -31,6 +31,8 @@ public:
 	PowerSaving(QObject * parent = 0);
 	~PowerSaving();
 
+	bool isValid();
+
 public slots:
 	void inhibit();
 	void uninhibit();

--- a/src/screensaver.cpp
+++ b/src/screensaver.cpp
@@ -42,6 +42,14 @@ ScreenSaver::~ScreenSaver() {
 #endif
 }
 
+bool ScreenSaver::isValid() {
+#ifdef Q_OS_WIN
+	return win_screensaver->isValid();
+#else
+	return power_saving->isValid();
+#endif
+}
+
 void ScreenSaver::enable() {
 #ifdef Q_OS_WIN
 	win_screensaver->enable();

--- a/src/screensaver.h
+++ b/src/screensaver.h
@@ -32,6 +32,8 @@ public:
 	ScreenSaver(QObject * parent = 0);
 	~ScreenSaver();
 
+	bool isValid();
+
 public slots:
 	void enable();
 	void disable();

--- a/src/winscreensaver.cpp
+++ b/src/winscreensaver.cpp
@@ -48,6 +48,14 @@ WinScreenSaver::~WinScreenSaver() {
 #endif
 }
 
+bool WinScreenSaver::isValid() {
+#ifndef Q_OS_OS2
+	return true;
+#else
+	return SSCore_TempDisable && SSCore_TempEnable;
+#endif
+}
+
 void WinScreenSaver::retrieveState() {
 	qDebug("WinScreenSaver::retrieveState");
 	

--- a/src/winscreensaver.h
+++ b/src/winscreensaver.h
@@ -34,6 +34,8 @@ public:
 	WinScreenSaver();
 	~WinScreenSaver();
 
+	bool isValid();
+
 	void disable();
 	void enable();
 


### PR DESCRIPTION
subj; in case the smplayer's controls are nonoperational.

Bug: https://github.com/smplayer-dev/smplayer/issues/1056