### PR TITLE
(Linux) Extend support for the XDG Base Directory

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -35,16 +35,18 @@ Translator * Global::translator = 0;
 
 using namespace Global;
 
-void Global::global_init(const QString & config_path) {
-	qDebug("global_init");
-
-	// Translator
-	translator = new Translator();
-
-	// settings
+void Global::init_settings(const QString & config_path) {
 	if (!config_path.isEmpty()) {
 		Paths::setConfigPath(config_path);
 	}
+	// fallback mechanism supports xdg directories
+	#if !defined(PORTABLE_APP) && defined(Q_OS_LINUX)
+	else {
+		settings = new QSettings(QSettings::IniFormat, QSettings::UserScope,
+		                         QString(PROGRAM), QString(PROGRAM) );
+		return;
+	}
+	#endif
 
 	if (Paths::iniPath().isEmpty()) {
 		settings = new QSettings(QSettings::IniFormat, QSettings::UserScope,
@@ -55,6 +57,16 @@ void Global::global_init(const QString & config_path) {
 		qDebug("global_init: config file: '%s'", filename.toUtf8().data());
 
 	}
+}
+
+void Global::global_init(const QString & config_path) {
+	qDebug("global_init");
+
+	// Translator
+	translator = new Translator();
+
+	// settings
+	init_settings(config_path);
 
 	// Preferences
 	pref = new Preferences();

--- a/src/global.h
+++ b/src/global.h
@@ -42,6 +42,7 @@ namespace Global {
 	extern Translator * translator;
 
 
+	void init_settings(const QString & config_path);
 	void global_init(const QString & config_path);
 	void global_end();
 


### PR DESCRIPTION
Create `QSettings` object with **fallback mechanism** that follows [XDG directories](https://specifications.freedesktop.org/basedir-spec/latest/): `$XDG_CONFIG_HOME` and `$XDG_CONFIG_DIRS`.

Only for Linux and when `-config-path` CLI option is empty.

This allows distribution maintainers to customize the default SMPlayer configuration using system-wide settings (in /etc/xdg directories).