### PR TITLE
Implement 'Pan view' mouse drag mode.

### DIFF
--- a/src/basegui.cpp
+++ b/src/basegui.cpp
@@ -6024,6 +6024,9 @@ void BaseGui::processMouseMovedDiff(QPoint diff) {
 	if (pref->drag_function == Preferences::MoveWindow && !pref->tablet_mode) {
 		moveWindowDiff(diff);
 	}
+	else if (pref->drag_function == Preferences::PanView && !pref->tablet_mode && mplayerwindow != nullptr) {
+		mplayerwindow->moveLayer(diff.x(), diff.y());
+	}
 }
 
 void BaseGui::moveWindowDiff(QPoint diff) {

--- a/src/mplayerwindow.cpp
+++ b/src/mplayerwindow.cpp
@@ -533,8 +533,13 @@ double MplayerWindow::zoom() { return zoom_factor; }
 void MplayerWindow::moveLayer( int offset_x, int offset_y ) {
 	int x = videolayer->x();
 	int y = videolayer->y();
-
-	videolayer->move( x + offset_x, y + offset_y );
+	int nx = x + offset_x;
+	int ny = y + offset_y;
+	if (nx > 0) { nx = 0; }
+	if (ny > 0) { ny = 0; }
+	if (nx < width() - videolayer->width() && videolayer->width() > width()) { nx = width() - videolayer->width(); }
+	if (ny < height() - videolayer->height() && videolayer->height() > height()) { ny = height() - videolayer->height(); }
+	videolayer->move(nx, ny);
 }
 
 void MplayerWindow::moveLeft() {

--- a/src/mplayerwindow.h
+++ b/src/mplayerwindow.h
@@ -123,6 +123,7 @@ public slots:
 	void moveRight();
 	void moveUp();
 	void moveDown();
+	void moveLayer( int offset_x, int offset_y );
 	void incZoom();
 	void decZoom();
 
@@ -141,7 +142,6 @@ protected:
 	virtual void mouseReleaseEvent( QMouseEvent * e);
 	virtual void mouseDoubleClickEvent( QMouseEvent * e );
 	virtual void wheelEvent( QWheelEvent * e );
-	void moveLayer( int offset_x, int offset_y );
 
 signals:
     //void rightButtonReleased( QPoint p );

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -47,7 +47,7 @@ public:
                     BelowNormal = 4, Idle = 5 };
 	enum WheelFunction { DoNothing = 1, Seeking = 2, Volume = 4, Zoom = 8,
                          ChangeSpeed = 16 };
-	enum DragFunction { DragDisabled = 0, MoveWindow = 1, Gestures = 2 };
+	enum DragFunction { DragDisabled = 0, MoveWindow = 1, Gestures = 2, PanView = 3 };
 	enum OptionState { Detect = -1, Disabled = 0, Enabled = 1 };
 	enum H264LoopFilter { LoopDisabled = 0, LoopEnabled = 1, LoopDisabledOnHD = 2 };
 	enum AutoAddToPlaylistFilter { NoFiles = 0, VideoFiles = 1, AudioFiles = 2, MultimediaFiles = 3, ConsecutiveFiles = 4 };

--- a/src/prefinput.cpp
+++ b/src/prefinput.cpp
@@ -173,6 +173,7 @@ void PrefInput::retranslateStrings() {
 	drag_function_combo->clear();
 	drag_function_combo->addItem( tr("None"), Preferences::DragDisabled);
 	drag_function_combo->addItem( tr("Move window"), Preferences::MoveWindow);
+	drag_function_combo->addItem( tr("Pan view"), Preferences::PanView);
 #ifdef MOUSE_GESTURES
 	drag_function_combo->addItem( tr("Seek and volume"), Preferences::Gestures);
 #endif


### PR DESCRIPTION
Implement feature request in issue #266 - at least half of it. Created an additional option (in English, translations not included) in the input prefs "Mouse drag function" box. Small line count for this change. I thought it would be better to separate the drag movement from any zooming functionality, as that could get more complicated.