### PR TITLE
Playlist pause button

### DIFF
--- a/src/basegui.cpp
+++ b/src/basegui.cpp
@@ -2527,6 +2527,8 @@ void BaseGui::createPlaylist() {
 	connect(playlist, SIGNAL(requestToPlayStream(const QString &, QStringList)),
             core, SLOT(openStream(const QString &, QStringList)));
 
+	connect(playlist, SIGNAL(requestToPause()), core, SLOT(pause()));
+
 	connect(playlist, SIGNAL(requestToAddCurrentFile()), this, SLOT(addToPlaylistCurrentFile()));
 
 	connect( core, SIGNAL(mediaFinished()), playlist, SLOT(playNextAuto()), Qt::QueuedConnection );

--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -520,6 +520,9 @@ void Playlist::createActions() {
 	playAct = new MyAction(this, "pl_play", false);
 	connect( playAct, SIGNAL(triggered()), this, SLOT(playCurrent()) );
 
+	pauseAct = new MyAction(this, "pl_pause", false);
+	connect( pauseAct, SIGNAL(triggered()), this, SLOT(pause()) );
+
 	nextAct = new MyAction(Qt::Key_N /*Qt::Key_Greater*/, this, "pl_next", false);
 	connect( nextAct, SIGNAL(triggered()), this, SLOT(playNext()) );
 
@@ -671,6 +674,7 @@ void Playlist::createToolbar() {
 
 	toolbar->addSeparator();
 	toolbar->addAction(playAct);
+	toolbar->addAction(pauseAct);
 	toolbar->addAction(prevAct);
 	toolbar->addAction(nextAct);
 #ifdef PLAYLIST_DOUBLE_TOOLBAR
@@ -740,11 +744,13 @@ void Playlist::retranslateStrings() {
 	saveAsAct->change( Images::icon("save"), tr("Save &as...") );
 
 	playAct->change( tr("&Play") );
+	pauseAct->change( tr("&Pause") );
 
 	nextAct->change( tr("&Next") );
 	prevAct->change( tr("Pre&vious") );
 
 	playAct->setIcon( Images::icon("play") );
+	pauseAct->setIcon( Images::icon("pause") );
 	nextAct->setIcon( Images::icon("next") );
 	prevAct->setIcon( Images::icon("previous") );
 
@@ -1505,6 +1511,11 @@ void Playlist::playCurrent() {
 	if (current > -1) {
 		playItem(current);
 	}
+}
+
+void Playlist::pause() {
+	qDebug("Playlist::pause");
+	emit requestToPause();
 }
 
 void Playlist::itemActivated(const QModelIndex & index ) {

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -245,6 +245,7 @@ public:
 signals:
 	void requestToPlayFile(const QString & filename, int seek = -1);
 	void requestToPlayStream(const QString & filename, QStringList params = QStringList());
+	void requestToPause();
 
 	void requestToAddCurrentFile();
 	void playlistEnded();
@@ -265,6 +266,7 @@ protected:
 
 protected slots:
 	void playCurrent();
+	void pause();
 	void itemActivated(const QModelIndex & index );
 	void headerClicked(int index);
 	void showPopup(const QPoint & pos);
@@ -351,6 +353,7 @@ protected:
 	MyAction * saveAct;
 	MyAction * saveAsAct;
 	MyAction * playAct;
+	MyAction * pauseAct;
 	MyAction * prevAct;
 	MyAction * nextAct;
 	MyAction * repeatAct;

--- a/src/shortcuts/default.keys
+++ b/src/shortcuts/default.keys
@@ -257,6 +257,7 @@ pl_open_url
 pl_save	
 pl_save_as	
 pl_play	
+pl_pause 
 pl_next	N
 pl_prev	P
 pl_move_up	

--- a/src/shortcuts/euskara.keys
+++ b/src/shortcuts/euskara.keys
@@ -224,6 +224,7 @@ restore/hide
 pl_open	
 pl_save	
 pl_play	
+pl_pause 
 pl_next	
 pl_prev	
 pl_move_up	

--- a/src/shortcuts/vlc.keys
+++ b/src/shortcuts/vlc.keys
@@ -232,6 +232,7 @@ restore/hide
 pl_open	
 pl_save	
 pl_play	
+pl_pause 
 pl_next	
 pl_prev	
 pl_move_up	


### PR DESCRIPTION
Add new `pl_pause` button to playlist window.

This is necessary for those scenarios when the main player window is on another screen (for example, an image projector), and the playlist window is at the operator's disposal on the first screen. 

Before this patch, he can switch and turn on videos in the playlist, but he cannot pause / unpause the video (from this playlist window).

<details> 
  <summary>Playlist window with new button</summary>
  
   ![pl_pause](https://github.com/user-attachments/assets/8c112920-e537-43e6-9a88-4d82303cd0b2)
   
</details>

P.S For example, `VLC` player provide this functionality with pause in playlist window.