### PR TITLE
Add Hold-to-Speed Feature for Quick Playback Control

### DIFF
--- a/src/basegui.cpp
+++ b/src/basegui.cpp
@@ -4923,6 +4923,11 @@ void BaseGui::leftButtonReleaseFunction() {
 
 void BaseGui::rightClickFunction() {
 	qDebug("BaseGui::rightClickFunction");
+	if (pref->enable_pressed_speed) {
+		if (core->mset.speed != 1.0) {	
+			core->setSpeed(1.0);
+		}
+	}
 
 	if (!pref->mouse_right_click_function.isEmpty()) {
 		processFunction(pref->mouse_right_click_function);

--- a/src/basegui.cpp
+++ b/src/basegui.cpp
@@ -2435,18 +2435,16 @@ void BaseGui::createMplayerWindow() {
 	panel->setLayout(layout);
 
 	// mplayerwindow
-	/*
-    connect( mplayerwindow, SIGNAL(rightButtonReleased(QPoint)),
-	         this, SLOT(showPopupMenu(QPoint)) );
-	*/
-
-	// mplayerwindow mouse events
-	connect( mplayerwindow, SIGNAL(doubleClicked()),
-             this, SLOT(doubleClickFunction()) );
-	connect( mplayerwindow, SIGNAL(leftClicked()),
-             this, SLOT(leftClickFunction()) );
+	connect( mplayerwindow, SIGNAL(leftButtonPressed()),
+             this, SLOT(leftButtonPressFunction()) );
+	connect( mplayerwindow, SIGNAL(leftButtonReleased()),
+             this, SLOT(leftButtonReleaseFunction()) );
 	connect( mplayerwindow, SIGNAL(rightClicked()),
              this, SLOT(rightClickFunction()) );
+	connect( mplayerwindow, SIGNAL(leftClicked()),
+             this, SLOT(leftClickFunction()) );
+	connect( mplayerwindow, SIGNAL(doubleClicked()),
+             this, SLOT(doubleClickFunction()) );
 	connect( mplayerwindow, SIGNAL(middleClicked()),
              this, SLOT(middleClickFunction()) );
 	connect( mplayerwindow, SIGNAL(xbutton1Clicked()),
@@ -4901,6 +4899,25 @@ void BaseGui::leftClickFunction() {
 
 	if (!pref->mouse_left_click_function.isEmpty()) {
 		processFunction(pref->mouse_left_click_function);
+	}
+}
+
+void BaseGui::leftButtonPressFunction() {
+	qDebug("BaseGui::leftButtonPressFunction");
+	if (pref->enable_pressed_speed) {
+		double speed = pref->pressed_speed;
+		if (speed != core->mset.speed) {
+			core->setSpeed(speed);
+		}
+	}
+}
+
+void BaseGui::leftButtonReleaseFunction() {
+	qDebug("BaseGui::leftButtonReleaseFunction");
+	if (pref->enable_pressed_speed) {
+		if (core->mset.speed != 1.0) {	
+			core->setSpeed(1.0);
+		}
 	}
 }
 

--- a/src/basegui.h
+++ b/src/basegui.h
@@ -297,7 +297,8 @@ protected slots:
 	virtual void mouseReleaseEvent( QMouseEvent * e );
 	virtual void mouseDoubleClickEvent( QMouseEvent * e );
 	*/
-
+	virtual void leftButtonPressFunction();
+	virtual void leftButtonReleaseFunction();
 	virtual void leftClickFunction();
 	virtual void rightClickFunction();
 	virtual void doubleClickFunction();

--- a/src/mplayerwindow.h
+++ b/src/mplayerwindow.h
@@ -133,11 +133,15 @@ protected slots:
 	void resizeLater();
 #endif
 
+protected slots:
+	void emitLeftButtonPressed();
+
 protected:
 	virtual void retranslateStrings();
 	virtual void changeEvent ( QEvent * event ) ;
 
 	virtual void resizeEvent( QResizeEvent * e);
+	virtual void mousePressEvent( QMouseEvent * e);
 	virtual void mouseReleaseEvent( QMouseEvent * e);
 	virtual void mouseDoubleClickEvent( QMouseEvent * e );
 	virtual void wheelEvent( QWheelEvent * e );
@@ -156,6 +160,8 @@ signals:
 	void wheelDown();
 	void mouseMovedDiff(QPoint);
 	void mouseMoved(QPoint);
+	void leftButtonPressed();
+	void leftButtonReleased();
 
 protected:
 	int video_width, video_height;
@@ -185,6 +191,7 @@ protected:
 	// Delay left click event
 	bool delay_left_click;
 	QTimer * left_click_timer;
+	QTimer * left_pressed_timer;
 	bool double_clicked;
 
 #if LOGO_ANIMATION
@@ -201,6 +208,7 @@ private:
 	TDragState drag_state;
 	QPoint start_drag;
 	bool mouse_drag_tracking;
+	bool left_button_pressed_emitted;
 };
 
 #endif

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -178,6 +178,9 @@ void Preferences::reset() {
 
 	global_speed = false;
 	speed = 1.0;
+	
+	enable_pressed_speed = true;
+	pressed_speed = 2.0;
 
 	autosync = false;
 	autosync_factor = 100;
@@ -758,6 +761,9 @@ void Preferences::save() {
 
 	set->setValue("global_speed", global_speed);
 	set->setValue("speed", speed);
+	
+	set->setValue("enable_pressed_speed", enable_pressed_speed);
+	set->setValue("pressed_speed", pressed_speed);
 
 	set->setValue("autosync", autosync);
 	set->setValue("autosync_factor", autosync_factor);
@@ -1357,6 +1363,9 @@ void Preferences::load() {
 
 	global_speed = set->value("global_speed", global_speed).toBool();
 	speed = set->value("speed", speed).toDouble();
+	
+	enable_pressed_speed = set->value("enable_pressed_speed", enable_pressed_speed).toBool();
+	pressed_speed = set->value("pressed_speed", pressed_speed).toDouble();
 
 	autosync = set->value("autosync", autosync).toBool();
 	autosync_factor = set->value("autosync_factor", autosync_factor).toInt();

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -154,6 +154,10 @@ public:
 	bool global_speed;
 	double speed;
 
+	// Pressed speed
+	bool enable_pressed_speed;
+	double pressed_speed;
+
 	bool autosync;
 	int autosync_factor;
 

--- a/src/prefinterface.cpp
+++ b/src/prefinterface.cpp
@@ -147,6 +147,9 @@ PrefInterface::PrefInterface(QWidget * parent, Qt::WindowFlags f)
 	tabWidget->setTabEnabled(HDPI_TAB, false);
 #endif
 
+	connect(enable_pressed_speed_check, SIGNAL(toggled(bool)), pressed_speed_label, SLOT(setEnabled(bool)));
+	connect(enable_pressed_speed_check, SIGNAL(toggled(bool)), pressed_speed_spin, SLOT(setEnabled(bool)));
+
 	retranslateStrings();
 }
 
@@ -294,6 +297,9 @@ void PrefInterface::setData(Preferences * pref) {
 #endif
 	setPreciseSeeking(pref->precise_seeking);
 
+	setEnablePressedSpeed(pref->enable_pressed_speed);
+	setPressedSpeed(pref->pressed_speed);
+
 	reset_stop_check->setChecked(pref->reset_stop);
 
 	setDefaultFont(pref->default_font);
@@ -369,6 +375,9 @@ void PrefInterface::getData(Preferences * pref) {
 	pref->relative_seeking= relativeSeeking();
 #endif
 	pref->precise_seeking = preciseSeeking();
+
+	pref->enable_pressed_speed = enablePressedSpeed();
+	pref->pressed_speed = pressedSpeed();
 
 	pref->reset_stop = reset_stop_check->isChecked();
 
@@ -595,6 +604,24 @@ void PrefInterface::setPreciseSeeking(bool b) {
 
 bool PrefInterface::preciseSeeking() {
 	return precise_seeking_check->isChecked();
+}
+
+void PrefInterface::setEnablePressedSpeed(bool b) {
+	enable_pressed_speed_check->setChecked(b);
+	pressed_speed_spin->setEnabled(b);
+	pressed_speed_label->setEnabled(b);
+}
+
+bool PrefInterface::enablePressedSpeed() {
+	return enable_pressed_speed_check->isChecked();
+}
+
+void PrefInterface::setPressedSpeed(double d) {
+	pressed_speed_spin->setValue(d);
+}
+
+double PrefInterface::pressedSpeed() {
+	return pressed_speed_spin->value();
 }
 
 void PrefInterface::setDefaultFont(QString font_desc) {
@@ -824,9 +851,15 @@ void PrefInterface::createHelp() {
 #endif
 
 	setWhatsThis(precise_seeking_check, tr("Precise seeking"),
-		tr("If this option is enabled, seeks are more accurate but they "
-           "can be a little bit slower. May not work with some video formats.") +"<br>"+
-		tr("Note: this option only works when using mpv as multimedia engine.") );
+		tr("If this option is checked, seeks are more accurate but they can be a little bit slower. "
+           "Note: this option only affects the slider behavior, it doesn't affect the seeking "
+           "by clicking on the waveform.") );
+
+	setWhatsThis(enable_pressed_speed_check, tr("Enable pressed speed"),
+		tr("If this option is checked, the playback speed will be changed when the left mouse button is pressed on the video window.") );
+
+	setWhatsThis(pressed_speed_spin, tr("Pressed speed"),
+		tr("If you hold the left mouse button in the video window, the media will be played at this speed.") );
 
 	setWhatsThis(reset_stop_check, tr("Pressing the stop button once resets the time position"),
 		tr("By default when the stop button is pressed the time position is remembered "

--- a/src/prefinterface.h
+++ b/src/prefinterface.h
@@ -100,6 +100,12 @@ protected:
 	void setPreciseSeeking(bool);
 	bool preciseSeeking();
 
+	void setEnablePressedSpeed(bool b);
+	bool enablePressedSpeed();
+
+	void setPressedSpeed(double d);
+	double pressedSpeed();
+
 	void setDefaultFont(QString font_desc);
 	QString defaultFont();
 

--- a/src/prefinterface.ui
+++ b/src/prefinterface.ui
@@ -614,6 +614,69 @@
          </property>
         </widget>
        </item>
+       <item row="7" column="0" colspan="2">
+        <widget class="QCheckBox" name="enable_pressed_speed_check">
+         <property name="text">
+          <string>Enable &amp;pressed speed</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
+        <layout class="QHBoxLayout" name="horizontalLayout_pressed_speed">
+         <item>
+          <widget class="QLabel" name="pressed_speed_label">
+           <property name="text">
+            <string>P&amp;ressed speed:</string>
+           </property>
+           <property name="buddy">
+            <cstring>pressed_speed_spin</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="pressed_speed_spin">
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>2.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_pressed_speed">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="9" column="0" colspan="2">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_2">


### PR DESCRIPTION
This PR adds a new "Pressed Speed" feature that allows users to temporarily change the playback speed by holding down the left mouse button in the video window. When the button is released, playback returns to normal speed.

Translations are missing for now and there are probably things that could be done better or cleaner. I personally was missing this feature - if there is interest I could extend on it.