### PR TITLE
Fix playlist position numbers after item removal

### DIFF
--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -1912,6 +1912,16 @@ void Playlist::removeSelected() {
 		if (current < 0) current = 0;
 		setCurrentItem(current);
 	}
+	updatePositionNumbers();
+}
+
+void Playlist::updatePositionNumbers() {
+	qDebug("Playlist::updatePositionNumbers");
+	
+	for (int n = 0; n < count(); n++) {
+		PLItem * item = itemData(n);
+		item->setPosition(n + 1);
+	}
 }
 
 void Playlist::removeAll() {
@@ -2077,6 +2087,9 @@ void Playlist::deleteSelectedFileFromDisk() {
 				if (findCurrentItem() == -1) {
 					if (current > 0) setCurrentItem(current-1); else setCurrentItem(0);
 				}
+				
+				// Update position numbers to avoid gaps
+				updatePositionNumbers();
 			} else {
 				QMessageBox::warning(this, tr("Deletion failed"),
 					tr("It wasn't possible to delete '%1'").arg(filename));

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -143,6 +143,8 @@ public slots:
 	void removeSelected();
 	void removeAll();
 
+	void updatePositionNumbers();
+
 	void addCurrentFile();
 	void addFiles();
 	void addDirectory();


### PR DESCRIPTION
When removing items from the playlist, the position numbers in the index column were not being updated, resulting in gaps in the numbering sequence.

Fixes #1146 

- Added a new `updatePositionNumbers()` method that iterates through all playlist items and updates their position numbers sequentially
- Modified `removeSelected()` to call this method after removing items
- Modified `deleteSelectedFileFromDisk()` to also call this method

