### PR TITLE
Rename YouTube video size options to decrease confusion

### DIFF
--- a/src/prefnetwork.cpp
+++ b/src/prefnetwork.cpp
@@ -44,10 +44,10 @@ PrefNetwork::PrefNetwork(QWidget * parent, Qt::WindowFlags f)
 	yt_resolution_combo->addItem( "240p", RetrieveYoutubeUrl::R240p );
 	yt_resolution_combo->addItem( "360p", RetrieveYoutubeUrl::R360p );
 	yt_resolution_combo->addItem( "480p", RetrieveYoutubeUrl::R480p );
-	yt_resolution_combo->addItem( "720p", RetrieveYoutubeUrl::R720p );
-	yt_resolution_combo->addItem( "1080p", RetrieveYoutubeUrl::R1080p );
-	yt_resolution_combo->addItem( "2K", RetrieveYoutubeUrl::R1440p );
-	yt_resolution_combo->addItem( "4K", RetrieveYoutubeUrl::R2160p );
+	yt_resolution_combo->addItem( "HD (720p)", RetrieveYoutubeUrl::R720p );
+	yt_resolution_combo->addItem( "Full HD (1080p)", RetrieveYoutubeUrl::R1080p );
+	yt_resolution_combo->addItem( "2K (1440p)", RetrieveYoutubeUrl::R1440p );
+	yt_resolution_combo->addItem( "4K (2160p)", RetrieveYoutubeUrl::R2160p );
 #endif
 
 	connect(streaming_type_combo, SIGNAL(currentIndexChanged(int)), this, SLOT(streaming_type_combo_changed(int)));


### PR DESCRIPTION
Fixes https://github.com/smplayer-dev/smplayer/issues/597