### PR TITLE
Save recents and video position on pause

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1376,6 +1376,7 @@ void Core::pause() {
 	qDebug() << "Core::pause: current state:" << stateToString();
 
         if (pref->remember_on_pause) {
+                qDebug("Saving recents and position");
                 pref->save();
                 saveMediaInfo();
         }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1375,8 +1375,10 @@ void Core::pause_and_frame_step() {
 void Core::pause() {
 	qDebug() << "Core::pause: current state:" << stateToString();
 
-	pref->save();
-	saveMediaInfo();
+        if (pref->remember_on_pause) {
+                pref->save();
+                saveMediaInfo();
+        }
 
 	if (proc->isRunning()) {
 		// Pauses and unpauses

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1375,6 +1375,9 @@ void Core::pause_and_frame_step() {
 void Core::pause() {
 	qDebug() << "Core::pause: current state:" << stateToString();
 
+	pref->save();
+	saveMediaInfo();
+
 	if (proc->isRunning()) {
 		// Pauses and unpauses
 		if (state() == Paused) proc->setPause(false); else proc->setPause(true);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -119,6 +119,7 @@ void Preferences::reset() {
 	remember_media_settings = true;
 	remember_time_pos = true;
 	remember_stream_settings = false;
+        remember_on_pause = false;
 
 #if SIMPLE_TRACK_SELECTION
 	alang = "";
@@ -704,6 +705,7 @@ void Preferences::save() {
 	set->setValue("remember_media_settings", remember_media_settings);
 	set->setValue("remember_time_pos", remember_time_pos);
 	set->setValue("remember_stream_settings", remember_stream_settings);
+        set->setValue("remember_on_pause", remember_on_pause);
 
 #if SIMPLE_TRACK_SELECTION
 	set->setValue("alang", alang);
@@ -1302,6 +1304,7 @@ void Preferences::load() {
 	remember_media_settings = set->value("remember_media_settings", remember_media_settings).toBool();
 	remember_time_pos = set->value("remember_time_pos", remember_time_pos).toBool();
 	remember_stream_settings = set->value("remember_stream_settings", remember_stream_settings).toBool();
+        remember_on_pause = set->value("remember_on_pause", remember_on_pause).toBool();
 
 #if SIMPLE_TRACK_SELECTION
 	alang = set->value("alang", alang).toString();

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -92,6 +92,7 @@ public:
 	bool remember_media_settings;
 	bool remember_time_pos;
 	bool remember_stream_settings;
+        bool remember_on_pause;
 
 #if SIMPLE_TRACK_SELECTION
 	QString alang;

--- a/src/prefgeneral.cpp
+++ b/src/prefgeneral.cpp
@@ -240,6 +240,7 @@ void PrefGeneral::setData(Preferences * pref) {
 	setRememberSettings( pref->remember_media_settings );
 	setRememberTimePos( pref->remember_time_pos );
 	remember_streams_check->setChecked(pref->remember_stream_settings);
+        remember_on_pause_check->setChecked(pref->remember_on_pause);
 
 	setFileSettingsMethod( pref->file_settings_method );
 
@@ -384,6 +385,7 @@ void PrefGeneral::getData(Preferences * pref) {
 	TEST_AND_SET(pref->remember_media_settings, rememberSettings());
 	TEST_AND_SET(pref->remember_time_pos, rememberTimePos());
 	TEST_AND_SET(pref->remember_stream_settings, remember_streams_check->isChecked());
+        TEST_AND_SET(pref->remember_on_pause, remember_on_pause_check->isChecked());
 
 	if (pref->file_settings_method != fileSettingsMethod()) {
 		pref->file_settings_method = fileSettingsMethod();

--- a/src/prefgeneral.ui
+++ b/src/prefgeneral.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>563</height>
+    <height>628</height>
    </rect>
   </property>
   <layout class="QVBoxLayout">
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="margin" stdset="0">
     <number>0</number>
    </property>
    <item>
@@ -58,7 +58,7 @@
          <item>
           <spacer name="player_spacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -85,13 +85,50 @@
           </item>
           <item>
            <layout class="QGridLayout">
-            <item row="0" column="0" rowspan="3">
+            <item row="3" column="1">
+             <layout class="QHBoxLayout">
+              <item>
+               <widget class="QLabel" name="filesettings_method_label">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>&amp;Store settings in</string>
+                </property>
+                <property name="buddy">
+                 <cstring>filesettings_method_combo</cstring>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="filesettings_method_combo">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="0" rowspan="4">
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Preferred</enum>
+               <enum>QSizePolicy::Policy::Preferred</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -117,43 +154,6 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout">
-              <item>
-               <widget class="QLabel" name="filesettings_method_label">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>&amp;Store settings in</string>
-                </property>
-                <property name="buddy">
-                 <cstring>filesettings_method_combo</cstring>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QComboBox" name="filesettings_method_combo">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer>
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
             <item row="1" column="1">
              <widget class="QCheckBox" name="remember_streams_check">
               <property name="enabled">
@@ -161,6 +161,13 @@
               </property>
               <property name="text">
                <string>Re&amp;member settings for streams</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QCheckBox" name="remember_on_pause_check">
+              <property name="text">
+               <string>Save time position on pause</string>
               </property>
              </widget>
             </item>
@@ -259,7 +266,7 @@
        <item>
         <widget class="Line" name="line_7">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -287,16 +294,16 @@
        <item>
         <widget class="QWidget" name="shutdown_widget" native="true">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="margin">
+          <property name="margin" stdset="0">
            <number>0</number>
           </property>
           <item>
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::Preferred</enum>
+             <enum>QSizePolicy::Policy::Preferred</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -319,7 +326,7 @@
           <item>
            <spacer name="horizontalSpacer_3">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -335,10 +342,10 @@
        <item>
         <spacer>
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
+          <enum>QSizePolicy::Policy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -396,7 +403,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -417,7 +424,7 @@
           </sizepolicy>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -426,7 +433,7 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
+         <property name="margin" stdset="0">
           <number>0</number>
          </property>
          <item>
@@ -439,7 +446,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -479,7 +486,7 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
+         <property name="margin" stdset="0">
           <number>0</number>
          </property>
          <item>
@@ -505,7 +512,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -555,7 +562,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -576,7 +583,7 @@
           </sizepolicy>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -617,7 +624,7 @@
           </sizepolicy>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -668,7 +675,7 @@
        <item>
         <spacer>
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -719,7 +726,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -740,7 +747,7 @@
           </sizepolicy>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -756,7 +763,7 @@
          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -790,7 +797,7 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
+         <property name="margin" stdset="0">
           <number>0</number>
          </property>
          <item>
@@ -809,7 +816,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -826,7 +833,7 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
+         <property name="margin" stdset="0">
           <number>0</number>
          </property>
          <item>
@@ -852,7 +859,7 @@
          <item>
           <spacer>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -870,7 +877,7 @@
           <string>Volume</string>
          </property>
          <layout class="QVBoxLayout">
-          <property name="margin">
+          <property name="margin" stdset="0">
            <number>4</number>
           </property>
           <item>
@@ -885,7 +892,7 @@
             <property name="spacing">
              <number>6</number>
             </property>
-            <property name="margin">
+            <property name="margin" stdset="0">
              <number>0</number>
             </property>
             <item>
@@ -898,7 +905,7 @@
             <item>
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -955,7 +962,7 @@
           <string>Synchronization</string>
          </property>
          <layout class="QVBoxLayout">
-          <property name="margin">
+          <property name="margin" stdset="0">
            <number>4</number>
           </property>
           <item>
@@ -970,10 +977,10 @@
             <item>
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Expanding</enum>
+               <enum>QSizePolicy::Policy::Expanding</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -992,7 +999,7 @@
                <string>&amp;Factor:</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
               <property name="wordWrap">
                <bool>false</bool>
@@ -1032,7 +1039,7 @@
             <item>
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1076,10 +1083,10 @@
        <item>
         <spacer>
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
+          <enum>QSizePolicy::Policy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1116,7 +1123,7 @@ For translators: don't translate this text, it will be replaced with another one
           </sizepolicy>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -1126,12 +1133,12 @@ For translators: don't translate this text, it will be replaced with another one
           <property name="spacing">
            <number>0</number>
           </property>
-          <property name="margin">
+          <property name="margin" stdset="0">
            <number>0</number>
           </property>
           <item>
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="margin" stdset="0">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -1140,7 +1147,7 @@ For translators: don't translate this text, it will be replaced with another one
             <item row="1" column="2">
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1153,7 +1160,7 @@ For translators: don't translate this text, it will be replaced with another one
             <item row="2" column="2">
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1172,7 +1179,7 @@ For translators: don't translate this text, it will be replaced with another one
                <string>&amp;Audio:</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
               <property name="wordWrap">
                <bool>false</bool>
@@ -1191,7 +1198,7 @@ For translators: don't translate this text, it will be replaced with another one
                <string>Su&amp;btitles:</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
               <property name="wordWrap">
                <bool>false</bool>
@@ -1216,7 +1223,7 @@ For translators: don't translate this text, it will be replaced with another one
        <item>
         <widget class="Line" name="tracks_separator">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -1226,12 +1233,12 @@ For translators: don't translate this text, it will be replaced with another one
           <property name="spacing">
            <number>0</number>
           </property>
-          <property name="margin">
+          <property name="margin" stdset="0">
            <number>0</number>
           </property>
           <item>
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="margin" stdset="0">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -1253,7 +1260,7 @@ For translators: don't translate this text, it will be replaced with another one
                <string>Audi&amp;o:</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
               <property name="buddy">
                <cstring>audio_track_spin</cstring>
@@ -1266,7 +1273,7 @@ For translators: don't translate this text, it will be replaced with another one
                <string>&amp;Subtitle:</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
               <property name="buddy">
                <cstring>subtitle_track_spin</cstring>
@@ -1276,7 +1283,7 @@ For translators: don't translate this text, it will be replaced with another one
             <item row="2" column="2">
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1289,7 +1296,7 @@ For translators: don't translate this text, it will be replaced with another one
             <item row="1" column="2">
              <spacer>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1321,7 +1328,7 @@ For translators: don't translate this text, it will be replaced with another one
        <item>
         <spacer>
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1368,7 +1375,6 @@ For translators: don't translate this text, it will be replaced with another one
   <tabstop>vo_combo</tabstop>
   <tabstop>vo_user_defined_edit</tabstop>
   <tabstop>vdpau_button</tabstop>
-  <tabstop>wayland_check</tabstop>
   <tabstop>postprocessing_check</tabstop>
   <tabstop>autoq_spin</tabstop>
   <tabstop>deinterlace_combo</tabstop>


### PR DESCRIPTION
It so happens that I sometimes shut down my devices while smplayer is still open, and recent files history and playback position are lost, and it's hard to continue watching from where I left off.
The default behavior should be unchanged, I made the setting opt-in.