### PR TITLE
Show audio bitrate only for audio only files

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -3880,13 +3880,13 @@ void Core::gotStartingTime(double time) {
 void Core::gotVideoBitrate(int b) {
 	//qDebug("Core::gotVideoBitrate: %d", b);
 	mdat.video_bitrate = b;
-	emit bitrateChanged(mdat.video_bitrate, mdat.audio_bitrate);
+	emit bitrateChanged(!mdat.novideo ? mdat.video_bitrate : -1, mdat.audio_bitrate);
 }
 
 void Core::gotAudioBitrate(int b) {
 	//qDebug("Core::gotAudioBitrate: %d", b);
 	mdat.audio_bitrate = b;
-	emit bitrateChanged(mdat.video_bitrate, mdat.audio_bitrate);
+	emit bitrateChanged(!mdat.novideo ? mdat.video_bitrate : -1, mdat.audio_bitrate);
 }
 
 void Core::gotDemuxRotation(int r) {

--- a/src/defaultgui.cpp
+++ b/src/defaultgui.cpp
@@ -783,7 +783,10 @@ void DefaultGui::displayVideoInfo(int width, int height, double fps) {
 }
 
 void DefaultGui::displayBitrateInfo(int vbitrate, int abitrate) {
-	bitrate_info_display->setText(tr("V: %1 kbps A: %2 kbps").arg(qRound(vbitrate/1000.0)).arg(qRound(abitrate/1000.0)));
+	QString text = tr("V: %1 kbps A: %2 kbps").arg(qRound(vbitrate/1000.0)).arg(qRound(abitrate/1000.0));
+	// if no video, display audio bitrate only (just cutting off the video part, to avoid an additional translation string)
+	if (vbitrate == -1) text = text.remove(QRegularExpression("^V: .* A: "));
+	bitrate_info_display->setText(text);
 }
 
 void DefaultGui::updateWidgets() {


### PR DESCRIPTION
If a media file doesn't contain video, only show the audio bitrate. Shows e.g. `128 kbps` instead of `V: 0 kbps A: 128 kbps` in the status bar.