### PR TITLE
patch for Qt6 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 # binaries
 /src/smplayer
 /webserver/simple_web_server
+webserver/simple_web_server.exe
+version
+src/smplayer.pro.user

--- a/src/actionseditor.cpp
+++ b/src/actionseditor.cpp
@@ -37,6 +37,9 @@
 #include <QMessageBox>
 #include <QFileInfo>
 #include <QRegExp>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegularExpression>
+#endif
 #include <QApplication>
 #include <QAction>
 #include <QDebug>
@@ -539,7 +542,9 @@ bool ActionsEditor::saveActionsTable(const QString & filename) {
 	QFile f( filename );
 	if ( f.open( QIODevice::WriteOnly ) ) {
 		QTextStream stream( &f );
+#if QT_VERSION_MAJOR < 6
 		stream.setCodec("UTF-8");
+#endif
 
 		for (int row = 0; row < table->rowCount(); row++) {
 			stream << table->item(row, COL_NAME)->text() << "\t" 
@@ -580,7 +585,9 @@ bool ActionsEditor::loadActionsTable(const QString & filename) {
 		#endif
 
 		QTextStream stream( &f );
-		stream.setCodec("UTF-8");
+#if QT_VERSION_MAJOR < 6
+        stream.setCodec("UTF-8");
+#endif
 
 		QString line;
 		while ( !stream.atEnd() ) {
@@ -588,7 +595,11 @@ bool ActionsEditor::loadActionsTable(const QString & filename) {
 			qDebug() << "ActionsEditor::loadActions: line:" << line;
 			QString name;
 			QString accelText;
-			int pos = line.indexOf(QRegExp("\\t|\\s"));
+#if QT_VERSION_MAJOR < 6
+            int pos = line.indexOf(QRegExp("\\t|\\s"));
+#else
+            int pos = line.indexOf(QRegularExpression("\\t|\\s"));
+#endif
 			//qDebug() << "ActionsEditor::loadActions: pos:" << pos;
 			if (pos == -1) {
 				name = line;

--- a/src/baseguiplus.cpp
+++ b/src/baseguiplus.cpp
@@ -35,7 +35,9 @@
 #include <QMenu>
 #include <QCloseEvent>
 #include <QApplication>
+#if QT_VERSION_MAJOR < 6
 #include <QDesktopWidget>
+#endif
 #include <QTime>
 
 #ifdef PLAYLIST_DOCKABLE
@@ -624,8 +626,16 @@ void BaseGuiPlus::aboutToEnterFullscreen() {
 	if (!playlist->isWindow() && playlistdock) {
 		playlistdock->setAllowedAreas(Qt::NoDockWidgetArea);
 
+#if QT_VERSION_MAJOR < 6
 		int playlist_screen = QApplication::desktop()->screenNumber(playlistdock);
 		int mainwindow_screen = QApplication::desktop()->screenNumber(this);
+#else
+        const QList<QScreen *> screens = QGuiApplication::screens();
+        QScreen *primaryScreen = QGuiApplication::primaryScreen();
+        QScreen *pldockScreen = playlistdock->windowHandle()->screen();
+        int playlist_screen = screens.indexOf(pldockScreen);
+        int mainwindow_screen = screens.indexOf(primaryScreen);
+#endif
 		qDebug("BaseGuiPlus::aboutToEnterFullscreen: mainwindow screen: %d, playlist screen: %d", mainwindow_screen, playlist_screen);
 
 		fullscreen_playlist_was_visible = playlistdock->isVisible();

--- a/src/colorutils.cpp
+++ b/src/colorutils.cpp
@@ -18,6 +18,9 @@
 
 #include "colorutils.h"
 #include <QWidget>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegExp>
+#endif
 #include <QDebug>
 #include "qtcompat.h"
 

--- a/src/defaultgui.cpp
+++ b/src/defaultgui.cpp
@@ -47,6 +47,9 @@
 #include <QMenuBar>
 #include <QMovie>
 #include <QtCore/qmath.h>
+#if QT_VERSION_MAJOR >= 6
+#include <QActionGroup>
+#endif
 
 #define TOOLBAR_VERSION "2"
 #define CONTROLWIDGET_VERSION "1"

--- a/src/deviceinfo.cpp
+++ b/src/deviceinfo.cpp
@@ -21,6 +21,9 @@
 #include <QProcess>
 #include <QFile>
 #include <QSettings>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegExp>
+#endif
 #include <QDebug>
 
 #ifdef Q_OS_WIN

--- a/src/favorites.cpp
+++ b/src/favorites.cpp
@@ -25,6 +25,9 @@
 #include <QTextStream>
 #include <QInputDialog>
 #include <QFileInfo>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegExp>
+#endif
 
 //#define FIRST_MENU_ENTRY 4
 #define FIRST_MENU_ENTRY 3
@@ -270,7 +273,11 @@ void Favorites::save() {
 	QFile f( _filename );
     if ( f.open( QIODevice::WriteOnly ) ) {
         QTextStream stream( &f );
+#if QT_VERSION_MAJOR < 6
 		stream.setCodec("UTF-8");
+#else
+        stream.setEncoding(QStringConverter::Utf8);
+#endif
 
 		stream << "#EXTM3U" << "\n";
 		for (int n = 0; n < f_list.count(); n++) {
@@ -299,7 +306,11 @@ void Favorites::load() {
 		Favorite fav;
 
 		QTextStream stream( &f );
-		stream.setCodec("UTF-8");
+#if QT_VERSION_MAJOR < 6
+        stream.setCodec("UTF-8");
+#else
+        stream.setEncoding(QStringConverter::Utf8);
+#endif
 
 		QString line;
 		while ( !stream.atEnd() ) {

--- a/src/findsubtitles/findsubtitleswindow.cpp
+++ b/src/findsubtitles/findsubtitleswindow.cpp
@@ -359,7 +359,11 @@ void FindSubtitlesWindow::currentItemChanged(const QModelIndex & current, const 
 }
 
 void FindSubtitlesWindow::applyFilter(const QString & filter) {
+#if QT_VERSION_MAJOR < 6
 	proxy_model->setFilterRegExp(filter);
+#else
+    proxy_model->setFilterRegularExpression(filter);
+#endif
 }
 
 void FindSubtitlesWindow::applyCurrentFilter() {

--- a/src/globalshortcuts/globalshortcuts.h
+++ b/src/globalshortcuts/globalshortcuts.h
@@ -42,7 +42,12 @@ public:
 	void setGrabbedKeys(MediaKeys keys);
 	MediaKeys grabbedKeys() { return grabbed_keys; };
 
-	virtual bool nativeEventFilter(const QByteArray & eventType, void * message, long * result);
+#if QT_VERSION_MAJOR < 6
+    virtual bool nativeEventFilter(const QByteArray & eventType, void * message, long * result);
+#else
+    virtual bool nativeEventFilter(const QByteArray & eventType, void * message, qintptr * result);
+#endif
+
 
 public slots:
 	void setEnabled(bool);

--- a/src/globalshortcuts/globalshortcuts_win.cpp
+++ b/src/globalshortcuts/globalshortcuts_win.cpp
@@ -17,9 +17,17 @@
 */
 
 #include <windows.h>
+#include <QDebug>
+#if QT_VERSION_MAJOR >= 6
+#include "globalshortcuts.h"
+#endif
 
+#if QT_VERSION_MAJOR < 6
 bool GlobalShortcuts::nativeEventFilter(const QByteArray & /*eventType*/, void * message, long * /*result*/) {
-	//qDebug() << "GlobalShortcuts::nativeEventFilter";
+#else
+bool GlobalShortcuts::nativeEventFilter(const QByteArray & /*eventType*/, void * message, qintptr * /*result*/) {
+#endif
+    //qDebug() << "GlobalShortcuts::nativeEventFilter";
 
 	if (!isEnabled()) return false;
 

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -24,6 +24,10 @@
 #include <QDir>
 #include <QTextCodec>
 #include <QWidget>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegExp>
+#include <QRegularExpression>
+#endif
 #include <QDebug>
 #include "config.h"
 #include "extensions.h"
@@ -253,7 +257,11 @@ QStringList Helper::searchForConsecutiveFiles(const QString & initial_file) {
 		digits = rx.cap(1).length();
 		current_number = rx.cap(1).toInt() + 1;
 		next_name = basename.left(pos) + QString("%1").arg(current_number, digits, 10, QLatin1Char('0'));
-		next_name.replace(QRegExp("([\\[\\]?*])"), "[\\1]");
+#if QT_VERSION_MAJOR < 6
+        next_name.replace(QRegExp("([\\[\\]?*])"), "[\\1]");
+#else
+        next_name.replace(QRegularExpression("([\\[\\]?*])"), "[\\1]");
+#endif
 		next_name += "*." + extension;
 		qDebug("Helper::searchForConsecutiveFiles: next name = %s",next_name.toUtf8().constData());
 		matching_files = dir.entryList((QStringList)next_name);
@@ -277,7 +285,11 @@ QStringList Helper::searchForConsecutiveFiles(const QString & initial_file) {
 			files_to_add << filename;
 			current_number++;
 			next_name = basename.left(pos) + QString("%1").arg(current_number, digits, 10, QLatin1Char('0'));
-			next_name.replace(QRegExp("([\\[\\]?*])"), "[\\1]");
+#if QT_VERSION_MAJOR < 6
+            next_name.replace(QRegExp("([\\[\\]?*])"), "[\\1]");
+#else
+            next_name.replace(QRegularExpression("([\\[\\]?*])"), "[\\1]");
+#endif
 			next_name += "*." + extension;
 			matching_files = dir.entryList((QStringList)next_name);
 			qDebug("Helper::searchForConsecutiveFiles: looking for '%s'", next_name.toUtf8().constData());

--- a/src/myapplication.cpp
+++ b/src/myapplication.cpp
@@ -53,7 +53,7 @@ MyApplication::MyApplication (const QString & /*appId*/, int & argc, char ** arg
 	: QApplication(argc, argv)
 #endif
 {
-#if QT_VERSION >= 0x050600
+#if QT_VERSION >= 0x050600 && QT_VERSION_MAJOR < 6
 	setFallbackSessionManagementEnabled(false);
 #endif
 #if QT_VERSION >= 0x050000

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -20,7 +20,9 @@
 #include <QLibraryInfo>
 #include <QLocale>
 #include <QFile>
-#include <QRegExp>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegularExpression>
+#endif
 #include <QDir>
 
 #ifndef Q_OS_WIN
@@ -123,8 +125,13 @@ QString Paths::doc(QString file, QString locale, bool english_fallback) {
 	qDebug("Helper:doc: checking '%s'", f.toUtf8().data());
 	if (QFile::exists(f)) return f;
 
-	if (locale.indexOf(QRegExp("_[A-Z]+")) != -1) {
-		locale.replace(QRegExp("_[A-Z]+"), "");
+#if QT_VERSION_MAJOR < 6
+    if (locale.indexOf(QRegExp("_[A-Z]+")) != -1) {
+        locale.replace(QRegExp("_[A-Z]+"), "");
+#else
+    if (locale.indexOf(QRegularExpression("_[A-Z]+")) != -1) {
+        locale.replace(QRegularExpression("_[A-Z]+"), "");
+#endif
 		f = docPath() + "/" + locale + "/" + file;
 		qDebug("Helper:doc: checking '%s'", f.toUtf8().data());
 		if (QFile::exists(f)) return f;

--- a/src/prefassociations.cpp
+++ b/src/prefassociations.cpp
@@ -27,6 +27,9 @@
 #include <QSettings>
 #include <QApplication>
 #include <QMessageBox>
+#if QT_VERSION_MAJOR >= 6
+#include <QOperatingSystemVersion>
+#endif
 #include "winfileassoc.h"
 #include "extensions.h"
 
@@ -48,10 +51,14 @@ PrefAssociations::PrefAssociations(QWidget * parent, Qt::WindowFlags f)
 
 	connect(selectAll, SIGNAL(clicked(bool)), this, SLOT(selectAllClicked(bool)));
 	connect(selectNone, SIGNAL(clicked(bool)), this, SLOT(selectNoneClicked(bool)));
-	connect(listWidget, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(listItemClicked(QListWidgetItem*))); 
-	connect(listWidget, SIGNAL(itemPressed(QListWidgetItem*)), this, SLOT(listItemPressed(QListWidgetItem*))); 
+    connect(listWidget, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(listItemClicked(QListWidgetItem*)));
+    connect(listWidget, SIGNAL(itemPressed(QListWidgetItem*)), this, SLOT(listItemPressed(QListWidgetItem*)));
 
+#if QT_VERSION_MAJOR < 6
 	if (QSysInfo::WindowsVersion >= QSysInfo::WV_VISTA)
+#else
+    if (QOperatingSystemVersion::current() >= QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 })
+#endif
 	{
 		//Hide Select None - One cannot restore an association in Vista. Go figure.
 		selectNone->hide(); 
@@ -148,7 +155,11 @@ void PrefAssociations::refreshList()
 				pItem->setCheckState(Qt::Checked);
 				//Don't allow de-selection in windows VISTA if extension is registered.
 				//VISTA doesn't seem to support extension 'restoration' in the API.
-				if (QSysInfo::WindowsVersion >= QSysInfo::WV_VISTA) {
+#if QT_VERSION_MAJOR < 6
+                if (QSysInfo::WindowsVersion >= QSysInfo::WV_VISTA) {
+#else
+                if (QOperatingSystemVersion::current() >= QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 }) {
+#endif
 					pItem->setFlags(QFlag(0));
 				}
 			}

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -40,6 +40,9 @@
 #if QT_VERSION >= 0x040400
 #include <QDesktopServices>
 #endif
+#if QT_VERSION_MAJOR >= 6
+#include <QOperatingSystemVersion>
+#endif
 
 #ifdef YOUTUBE_SUPPORT
 #include "retrieveyoutubeurl.h"
@@ -84,10 +87,14 @@ void Preferences::reset() {
 #endif
 
 #if defined(Q_OS_WIN) || defined(Q_OS_OS2)
-	mplayer_bin= "mpv/mpv.exe";
-	if (QSysInfo::WindowsVersion < QSysInfo::WV_WINDOWS7) {
+    mplayer_bin= "mpv/mpv.exe";
+#if QT_VERSION_MAJOR < 6
+    if (QSysInfo::WindowsVersion < QSysInfo::WV_WINDOWS7) {
+#else
+    if (QOperatingSystemVersion::current() < QOperatingSystemVersion::Windows7) {
+#endif
 		mplayer_bin= "mplayer/mplayer.exe";
-	}
+    }
 #else
 	mplayer_bin = "mpv";
 #endif
@@ -1911,9 +1918,13 @@ void Preferences::load() {
 		}
 		if (config_version <= 5) {
 			#ifdef Q_OS_WIN
-			if (QSysInfo::WindowsVersion < QSysInfo::WV_WINDOWS7) {
+            #if QT_VERSION_MAJOR < 6
+            if (QSysInfo::WindowsVersion < QSysInfo::WV_WINDOWS7) {
+            #else
+            if (QOperatingSystemVersion::current() < QOperatingSystemVersion::Windows7) {
+            #endif
 				mplayer_bin= "mplayer/mplayer.exe";
-			}
+            }
 			#else
 			use_audio_equalizer = false;
 			initial_volnorm = false;

--- a/src/prefinterface.cpp
+++ b/src/prefinterface.cpp
@@ -29,6 +29,9 @@
 #include <QDir>
 #include <QStyleFactory>
 #include <QFontDialog>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegExp>
+#endif
 #include <QDebug>
 
 #ifdef HDPI_SUPPORT

--- a/src/prefperformance.cpp
+++ b/src/prefperformance.cpp
@@ -22,6 +22,9 @@
 #include "global.h"
 #include "preferences.h"
 #include "playerid.h"
+#if QT_VERSION_MAJOR >= 6
+#include <QOperatingSystemVersion>
+#endif
 
 using namespace Global;
 
@@ -51,11 +54,15 @@ PrefPerformance::PrefPerformance(QWidget * parent, Qt::WindowFlags f)
 	#ifdef Q_OS_WIN
 	hwdec_combo->addItem("dxva2", "dxva2");
 	hwdec_combo->addItem("dxva2-copy", "dxva2-copy");
-	if (QSysInfo::WindowsVersion >= QSysInfo::WV_WINDOWS8) {
-		// Windows 8+
+    #if QT_VERSION_MAJOR < 6
+    if (QSysInfo::WindowsVersion >= QSysInfo::WV_WINDOWS8) {
+    #else
+    if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows8) {
+    #endif
+        // Windows 8+
 		hwdec_combo->addItem("d3d11va", "d3d11va");
 		hwdec_combo->addItem("d3d11va-copy", "d3d11va-copy");
-	}
+    }
 	#endif
 	hwdec_combo->addItem("nvdec", "nvdec");
 	hwdec_combo->addItem("nvdec-copy", "nvdec-copy");

--- a/src/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/qtsingleapplication/qtlocalpeer.cpp
@@ -43,6 +43,9 @@
 #include <QCoreApplication>
 #include <QDataStream>
 #include <QTime>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegularExpression>
+#endif
 
 #if defined(Q_OS_WIN)
 #include <QLibrary>
@@ -78,7 +81,11 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
 #endif
         prefix = id.section(QLatin1Char('/'), -1);
     }
+#if QT_VERSION_MAJOR < 6
     prefix.remove(QRegExp("[^a-zA-Z]"));
+#else
+    prefix.remove(QRegularExpression("[^a-zA-Z]"));
+#endif
     prefix.truncate(6);
 
     QByteArray idc = id.toUtf8();

--- a/src/smplayer.cpp
+++ b/src/smplayer.cpp
@@ -46,6 +46,9 @@
 #include <QDir>
 #include <QUrl>
 #include <QTime>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegExp>
+#endif
 #include <stdio.h>
 
 #ifdef Q_OS_WIN
@@ -580,8 +583,9 @@ void SMPlayer::createFontFile() {
 
 void SMPlayer::showInfo() {
 #ifdef Q_OS_WIN
-	QString win_ver;
-	switch (QSysInfo::WindowsVersion) {
+#if QT_VERSION_MAJOR < 6
+    QString win_ver;
+    switch (QSysInfo::WindowsVersion) {
 		case QSysInfo::WV_2000: win_ver = "Windows 2000"; break;
 		case QSysInfo::WV_XP: win_ver = "Windows XP"; break;
 		case QSysInfo::WV_2003: win_ver = "Windows XP Professional x64/Server 2003"; break;
@@ -601,6 +605,9 @@ void SMPlayer::showInfo() {
 		case QSysInfo::WV_NT_based: win_ver = "NT-based Windows"; break;
 		default: win_ver = QString("Unknown/Unsupported Windows OS"); break;
 	}
+#else
+    QString win_ver("Windows " + QSysInfo::productVersion());
+#endif
 #endif
 	QString s = QObject::tr("This is SMPlayer v. %1 running on %2")
            .arg(Version::printable())

--- a/src/smplayer.pro
+++ b/src/smplayer.pro
@@ -1,8 +1,8 @@
 TEMPLATE = app
 LANGUAGE = C++
 
-CONFIG += qt warn_on
-CONFIG += release
+CONFIG += qt warn_on lrelease
+#CONFIG += release
 #CONFIG += debug
 
 QT += network xml
@@ -60,6 +60,25 @@ greaterThan(QT_MAJOR_VERSION, 4):greaterThan(QT_MINOR_VERSION, 3) {
 #DEFINES += IDOPT_BUILD
 
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x050F00
+
+win32 {
+    CONFIG(debug, debug|release) {
+        BUILD_SUBDIR = debug
+    } else {
+        BUILD_SUBDIR = release
+    }
+    QM_SRC_DIR = $${OUT_PWD}/$${BUILD_SUBDIR}
+    QM_DST_DIR = $${OUT_PWD}/$${BUILD_SUBDIR}/translations
+    QMAKE_POST_LINK += $$quote(cmd /c if not exist $$shell_quote($$replace(QM_DST_DIR,"/","\\")) mkdir $$shell_quote($$replace(QM_DST_DIR,"/","\\")))$$escape_expand(\n\t)
+    QMAKE_POST_LINK += $$quote(cmd /c copy /y $$shell_quote($$replace(QM_SRC_DIR,"/","\\")\\)*.qm $$shell_quote($$replace(QM_DST_DIR,"/","\\")))$$escape_expand(\n\t)
+    QMAKE_CLEAN += $${QM_DST_DIR}/*.qm
+} else {
+    QM_SRC_DIR = $${OUT_PWD}
+    QM_DST_DIR = $${OUT_PWD}/translations
+    QMAKE_POST_LINK += mkdir -p $${QM_DST_DIR}$$escape_expand(\n\t)
+    QMAKE_POST_LINK += cp $${QM_SRC_DIR}/*.qm $${QM_DST_DIR}$$escape_expand(\n\t)
+    QMAKE_CLEAN += $${QM_DST_DIR}/*.qm
+}
 
 contains( DEFINES, SIMPLE_BUILD ) {
 	DEFINES -= SINGLE_INSTANCE
@@ -417,7 +436,8 @@ contains( DEFINES, FIND_SUBTITLES ) {
 	SOURCES += findsubtitles/qrestapi/qRestAPI.cpp findsubtitles/qrestapi/qRestResult.cpp \
                findsubtitles/qrestapi/qGirderAPI.cpp findsubtitles/osclient.cpp
 
-	isEqual(QT_MAJOR_VERSION, 5) {
+        I
+	greaterThan(QT_MAJOR_VERSION, 4) {
 		QT += qml
 	} else {
 		QT += script
@@ -640,10 +660,6 @@ contains( DEFINES, USE_SHM|USE_COREVIDEO_BUFFER ) {
 		LIBS += -framework Cocoa
 	}
 
-	isEqual(QT_MAJOR_VERSION, 5) {
-		#DEFINES += USE_GL_WINDOW
-	}
-
 	contains( DEFINES, USE_GL_WINDOW ) {
 		HEADERS += openglrenderer.h
 		SOURCES += openglrenderer.cpp
@@ -664,7 +680,7 @@ contains( DEFINES, USE_SHM|USE_COREVIDEO_BUFFER ) {
 
 contains(DEFINES, USE_SMTUBE_LIB) {
 	LIBS += -L../smtube -lsmtube
-	isEqual(QT_MAJOR_VERSION, 5) {
+	greaterThan(QT_MAJOR_VERSION, 4) {
 		QT += webkitwidgets widgets gui
 	} else {
 		QT += webkit
@@ -774,4 +790,3 @@ TRANSLATIONS = translations/smplayer_es.ts translations/smplayer_es_ES.ts \
                translations/smplayer_sq_AL.ts translations/smplayer_am.ts \
                translations/smplayer_fa.ts translations/smplayer_en_US.ts \
                translations/smplayer_nb_NO.ts
-

--- a/src/smplayer.pro
+++ b/src/smplayer.pro
@@ -259,6 +259,7 @@ HEADERS += guiconfig.h \
 	clhelp.h \
 	cleanconfig.h \
 	smplayer.h \
+	svn_revision.h \
 	myapplication.h
 
 

--- a/src/subreader.cpp
+++ b/src/subreader.cpp
@@ -26,7 +26,11 @@
 
 #define NL QString("\r\n")
 #define BNL QByteArray("\r\n")
+#if QT_VERSION_MAJOR < 6
 #define BOM QString(0xFEFF)
+#else
+#define BOM QString(QByteArray('0xFE', '0xFF'))
+#endif
 
 SubReader::SubReader() {
 	input_codec = "ISO-8859-1";

--- a/src/winfileassoc.cpp
+++ b/src/winfileassoc.cpp
@@ -40,6 +40,9 @@
 #include <QSettings>
 #include <QApplication>
 #include <QFileInfo>
+#if QT_VERSION_MAJOR >= 6
+#include <QOperatingSystemVersion>
+#endif
 #include <windows.h>
 
 WinFileAssoc::WinFileAssoc(const QString ClassId, const QString AppName)
@@ -53,7 +56,11 @@ WinFileAssoc::WinFileAssoc(const QString ClassId, const QString AppName)
 // Returns number of extensions processed successfully.
 int WinFileAssoc::CreateFileAssociations(const QStringList &fileExtensions)
 {
+#if QT_VERSION_MAJOR < 6
     if (QSysInfo::WindowsVersion >= QSysInfo::WV_VISTA) {
+#else
+    if (QOperatingSystemVersion::current() >= QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 }) {
+#endif
         return VistaSetAppsAsDefault(fileExtensions);
     }
 
@@ -122,7 +129,11 @@ bool WinFileAssoc::GetRegisteredExtensions(const QStringList &extensionsToCheck,
 {
     registeredExtensions.clear();
 
+#if QT_VERSION_MAJOR < 6
     if (QSysInfo::WindowsVersion >= QSysInfo::WV_VISTA) {
+#else
+    if (QOperatingSystemVersion::current() >= QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 }) {
+#endif
         return VistaGetDefaultApps(extensionsToCheck, registeredExtensions);
     }
 
@@ -170,7 +181,11 @@ bool WinFileAssoc::GetRegisteredExtensions(const QStringList &extensionsToCheck,
 // Returns number of extensions successfully processed (error if fileExtensions.count() != return value && count > 0).
 int WinFileAssoc::RestoreFileAssociations(const QStringList &fileExtensions)
 {
+#if QT_VERSION_MAJOR < 6
     if (QSysInfo::WindowsVersion >= QSysInfo::WV_VISTA)
+#else
+    if (QOperatingSystemVersion::current() >= QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 })
+#endif
         return 0; // Not supported by the API
 
     QSettings RegCR("HKEY_CLASSES_ROOT", QSettings::NativeFormat);

--- a/src/winscreensaver.cpp
+++ b/src/winscreensaver.cpp
@@ -16,8 +16,12 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#include <Qt>
 #include <QSysInfo>
+#if QT_VERSION_MAJOR < 6
+#include <Qt>
+#else
+#include <QOperatingSystemVersion>
+#endif
 #include "winscreensaver.h"
 #ifndef Q_OS_OS2
 #include <windows.h>
@@ -53,7 +57,11 @@ void WinScreenSaver::retrieveState() {
 	
 	if (!state_saved) {
 #ifndef Q_OS_OS2
+#if QT_VERSION_MAJOR < 6
 		if (QSysInfo::WindowsVersion < QSysInfo::WV_VISTA) {
+#else
+        if (QOperatingSystemVersion::current() < QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 }) {
+#endif
 			// Not supported on Windows Vista
 			SystemParametersInfo(SPI_GETLOWPOWERTIMEOUT, 0, &lowpower, 0);
 			SystemParametersInfo(SPI_GETPOWEROFFTIMEOUT, 0, &poweroff, 0);
@@ -79,8 +87,12 @@ void WinScreenSaver::restoreState() {
 	
 	if (state_saved) {
 #ifndef Q_OS_OS2
-		if (QSysInfo::WindowsVersion < QSysInfo::WV_VISTA) {
-			// Not supported on Windows Vista
+#if QT_VERSION_MAJOR < 6
+        if (QSysInfo::WindowsVersion < QSysInfo::WV_VISTA) {
+#else
+        if (QOperatingSystemVersion::current() < QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 }) {
+#endif
+            // Not supported on Windows Vista
 			SystemParametersInfo(SPI_SETLOWPOWERTIMEOUT, lowpower, NULL, 0);
 			SystemParametersInfo(SPI_SETPOWEROFFTIMEOUT, poweroff, NULL, 0);
 		}
@@ -112,8 +124,12 @@ void WinScreenSaver::disable() {
 	qDebug("WinScreenSaver::disable");
 
 #ifndef Q_OS_OS2
-	if (QSysInfo::WindowsVersion < QSysInfo::WV_VISTA) {
-		// Not supported on Windows Vista
+#if QT_VERSION_MAJOR < 6
+    if (QSysInfo::WindowsVersion < QSysInfo::WV_VISTA) {
+#else
+    if (QOperatingSystemVersion::current() < QOperatingSystemVersionBase{ QOperatingSystemVersionBase::Windows, 6, 0 }) {
+#endif
+        // Not supported on Windows Vista
 		SystemParametersInfo(SPI_SETLOWPOWERTIMEOUT, 0, NULL, 0);
 		SystemParametersInfo(SPI_SETPOWEROFFTIMEOUT, 0, NULL, 0);
 	}

--- a/src/winscreensaver.h
+++ b/src/winscreensaver.h
@@ -24,8 +24,10 @@
 #ifdef Q_OS_OS2
 #include <QLibrary>
 #else
+#if QT_VERSION_MAJOR < 6
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0501
+#endif
 #endif
 
 class WinScreenSaver

--- a/src/youtube/codedownloader.cpp
+++ b/src/youtube/codedownloader.cpp
@@ -20,6 +20,9 @@
 #include "retrieveyoutubeurl.h"
 #include <QFile>
 #include <QMessageBox>
+#if QT_VERSION_MAJOR >= 6
+#include <QRegExp>
+#endif
 #include <QDebug>
 
 #include <QDir>

--- a/webserver/mongoose.h
+++ b/webserver/mongoose.h
@@ -210,7 +210,7 @@
 #include <windows.h>
 #include <process.h>
 
-#if _MSC_VER < 1700
+#if defined( _MSC_VER ) && _MSC_VER < 1700
 typedef int bool;
 #else
 #include <stdbool.h>


### PR DESCRIPTION
Quick patch for Qt6 build. Confirmed that SMPlayer can be built with Qt6.8.3+minGW13.1.0 and Qt5.15.2+minGW12.0.0, and both are working well.