### PR TITLE
Add support network URI schemes for KDE

### DIFF
--- a/smplayer.desktop
+++ b/smplayer.desktop
@@ -7,6 +7,7 @@ Icon=smplayer
 MimeType=audio/ac3;audio/mp4;audio/mpeg;audio/vnd.rn-realaudio;audio/vorbis;audio/x-adpcm;audio/x-matroska;audio/x-mp2;audio/x-mp3;audio/x-ms-wma;audio/x-vorbis;audio/x-wav;audio/mpegurl;audio/x-mpegurl;audio/x-pn-realaudio;audio/x-scpls;audio/aac;audio/flac;audio/ogg;video/avi;video/mp4;video/flv;video/mpeg;video/quicktime;video/vnd.rn-realvideo;video/x-matroska;video/x-ms-asf;video/x-msvideo;video/x-ms-wmv;video/x-ogm+ogg;video/x-theora;video/webm;
 Name=SMPlayer
 Type=Application
+X-KDE-Protocols=appending,archive,av,avdevice,bd,bdnav,bluray,bluraynav,br,brnav,cdda,concat,data,dvb,dvd,dvdnav,edl,fd,fdclose,ffmpeg,file,ftp,gopher,gophers,hex,http,httpproxy,https,lavf,md5,memory,mf,mms,mmsh,mmshttp,mmst,null,rtmp,rtmpe,rtmps,rtmpt,rtmpte,rtmpts,rtp,rtsp,rtsps,sftp,slice,smb,srt,srtp,tcp,tls,udp,unix
 X-KDE-StartupNotify=false
 
 # Translations


### PR DESCRIPTION
List of protocols is built from common protocols
listed in `mpv --list-protocols` on two different systems.