### PR TITLE
smplayer.desktop Comment should say about mpv, not mplayer

### DIFF
--- a/smplayer.desktop
+++ b/smplayer.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Categories=Qt;AudioVideo;Player;Video;
-Comment=A great MPlayer front-end
+Comment=A great mpv front-end
 Exec=smplayer %U
 GenericName=Media Player
 Icon=smplayer


### PR DESCRIPTION
Reason: on most desktop Linux operating systems, when I install smplayer, mpv gets installed as a dependency.
Not mplayer.