### PR TITLE
Cast mpris:length value to qint64

### DIFF
--- a/src/mpris2/mediaplayer2player.cpp
+++ b/src/mpris2/mediaplayer2player.cpp
@@ -164,7 +164,7 @@ QVariantMap MediaPlayer2Player::Metadata() const {
 	}
 
 	metaData["mpris:trackid"] = QVariant::fromValue<QDBusObjectPath>(QDBusObjectPath(makeTrackId(m_core->mdat.filename).constData()));
-	metaData["mpris:length"] = m_core->mdat.duration * 1000000;
+	metaData["mpris:length"] = static_cast<qint64>(m_core->mdat.duration * 1000000);
 
 	// m_core->mdat.stream_url is never set
 	metaData["xesam:url"] = m_core->mdat.filename;


### PR DESCRIPTION
According to the mpris guidelines[1] the mpris:length metadata entry should have type "64-bit integer" rather than double.

[1]: https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#mpris:length