### PR TITLE
Add actions to play the first and the last file in the playlist

### DIFF
--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -560,6 +560,12 @@ void Playlist::createActions() {
 	prevAct = new MyAction(Qt::Key_P /*Qt::Key_Less*/, this, "pl_prev", false);
 	connect( prevAct, SIGNAL(triggered()), this, SLOT(playPrev()) );
 
+	firstAct = new MyAction(this, "pl_first", false);
+	connect( firstAct, SIGNAL(triggered()), this, SLOT(playFirst()) );
+
+	lastAct = new MyAction(this, "pl_last", false);
+	connect( lastAct, SIGNAL(triggered()), this, SLOT(playLast()) );
+
 	moveUpAct = new MyAction(this, "pl_move_up", false);
 	connect( moveUpAct, SIGNAL(triggered()), this, SLOT(upItem()) );
 
@@ -779,6 +785,9 @@ void Playlist::retranslateStrings() {
 
 	nextAct->change( tr("&Next") );
 	prevAct->change( tr("Pre&vious") );
+
+	firstAct->change( tr("&First") );
+	lastAct->change( tr("&Last") );
 
 	playAct->setIcon( Images::icon("play") );
 	pauseAct->setIcon( Images::icon("pause") );
@@ -1720,6 +1729,16 @@ void Playlist::playPrev() {
 	} else {
 		if (proxy->rowCount() > 1) playItem(proxy->rowCount() - 1, delayed_play);
 	}
+}
+
+void Playlist::playFirst() {
+	qDebug("Playlist::playFirst");
+	playItem(0);
+}
+
+void Playlist::playLast() {
+	qDebug("Playlist::playLast");
+	playItem(proxy->rowCount()-1);
 }
 
 void Playlist::playNextAuto() {

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -136,6 +136,9 @@ public slots:
 	void playNext();
 	void playPrev();
 
+	void playFirst();
+	void playLast();
+
 	void playNextAuto(); // Called from GUI when a file finished
 
 	void resumePlay();
@@ -358,6 +361,8 @@ protected:
 	MyAction * pauseAct;
 	MyAction * prevAct;
 	MyAction * nextAct;
+	MyAction * firstAct;
+	MyAction * lastAct;
 	MyAction * repeatAct;
 	MyAction * shuffleAct;
 	MyAction * showSearchAct;


### PR DESCRIPTION
I need the option to jump to the first file of the current playlist via script. Using the action pl_prev repeatedly doesn't work, as it doesn't give any feedback when the first file is reached. It also potentially takes a long time for longer playlists. I personally don't need the pl_last action , but it felt right to me to provide both options

I also tried to add an option to play the nth file in the playlist, but I don't think it's possible to pass anything but a boolean parameter via `-send-action`/ `QAction::triggered()`.