### PR TITLE
feat: playlist positions are remembered

### DIFF
--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -66,7 +66,10 @@
 #include "multilineinputdialog.h"
 #include "version.h"
 #include "extensions.h"
+#include "filehash.h"
+#include "filesettings.h"
 #include "guiconfig.h"
+#include "paths.h"
 
 #ifdef CHROMECAST_SUPPORT
 #include "chromecast.h"
@@ -148,6 +151,58 @@ private:
 	mutable QCollator collator;
 };
 #endif
+
+
+/* ----------------------------------------------------------- */
+
+/**
+ * The attributes to be saved for each playlist
+ */
+struct PlaylistSettingsPerFile
+{
+	int current_position = 0;
+};
+
+/**
+ * Loads from configuration file the playlist settings for a specific playlist_path
+ * @param playlist_path input path of a playlist file
+ * @param config_path input path to INI configuration file to read
+ * @param playlist_settings output settings
+ */
+void loadPlaylistSettingsPerFile(QString const& playlist_path, QString const&config_path, PlaylistSettingsPerFile& playlist_settings )
+{
+	qDebug() << "loadPlaylistSettingsPerFile:" << playlist_path << config_path;
+	if (playlist_path.isEmpty()) return;
+	QSettings settings(config_path, QSettings::IniFormat);
+	QString const hash = FileHash::calculateHash(playlist_path);
+	if (hash.isEmpty()) return;
+	settings.beginGroup(hash);
+	if (settings.contains("current_position"))
+	{
+		playlist_settings.current_position = settings.value("current_position", 0).toInt();
+	}
+	else
+	{
+		qDebug() << "loadPlaylistSettingsPerFile" << "associated playlist file not found";
+	}
+}
+
+/**
+ * Saves to configuration file the playlist settings for a specific playlist_path
+ * @param playlist_path input path of current playlist
+ * @param config_path input path to INI configuration file to write
+ * @param playlist_settings input settings
+ */
+void savePlaylistSettingsPerFile(QString const& playlist_path, QString const& config_path, PlaylistSettingsPerFile const& playlist_settings)
+{
+	qDebug() << "savePlaylistSettingsPerFile" << playlist_path << config_path << playlist_settings.current_position;
+	if (playlist_path.isEmpty()) return;
+	QSettings settings(config_path, QSettings::IniFormat);
+	QString const hash = FileHash::calculateHash(playlist_path);
+	if (hash.isEmpty()) return;
+	settings.beginGroup(hash);
+	settings.setValue("current_position", playlist_settings.current_position);
+}
 
 
 /* ----------------------------------------------------------- */
@@ -885,6 +940,8 @@ void Playlist::setCurrentItem(int current) {
 
 	listView->clearSelection();
 	listView->selectionModel()->setCurrentIndex(listView->model()->index(current, 0), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
+
+	savePosition();
 }
 
 int Playlist::findCurrentItem() {
@@ -910,9 +967,10 @@ int Playlist::findCurrentItem() {
 }
 
 void Playlist::clear() {
+	qDebug() << "Playlist::clear";
+	if (!isEmpty()) setModified(true);
 	table->setRowCount(0);
 	setCurrentItem(0);
-	setModified(false);
 }
 
 int Playlist::count() {
@@ -1526,14 +1584,20 @@ bool Playlist::save(const QString & filename) {
 
 		QString suffix = QFileInfo(s).suffix().toLower();
 		if (suffix  == "pls") {
-			return save_pls(s);
+			bool return_val = save_pls(s);
+			savePosition();
+			return return_val;
 		}
 		else
 		if (suffix  == "xspf") {
-			return saveXSPF(s);
+			bool return_val = saveXSPF(s);
+			savePosition();
+			return return_val;
 		}
 		else {
-			return save_m3u(s);
+			bool return_val = save_m3u(s);
+			savePosition();
+			return return_val;
 		}
 
 	} else {
@@ -1630,7 +1694,7 @@ void Playlist::showPopup(const QPoint & pos) {
 }
 
 void Playlist::startPlay() {
-	playItem(0);
+	playItem(loadPosition());
 }
 
 void Playlist::playItem(int n, bool later) {
@@ -2706,6 +2770,25 @@ void Playlist::resort() {
 	int col = listView->horizontalHeader()->sortIndicatorSection();
 	Qt::SortOrder order = listView->horizontalHeader()->sortIndicatorOrder();
 	listView->sortByColumn(col, order);
+}
+
+void Playlist::savePosition()
+{
+	if (!modified)
+	{
+		PlaylistSettingsPerFile playlist_settings;
+		playlist_settings.current_position = findCurrentItem();
+		// PlaylistSettings2Saver::save(playlist_path + "/" + playlist_filename, Paths::configPath() + "/playlist_per_file.ini", playlist_settings);
+		savePlaylistSettingsPerFile(playlist_filename, Paths::configPath() + "/playlist_per_file.ini", playlist_settings);
+	}
+}
+
+int Playlist::loadPosition()
+{
+	PlaylistSettingsPerFile playlist_settings;
+	loadPlaylistSettingsPerFile(playlist_filename, Paths::configPath() + "/playlist_per_file.ini", playlist_settings);
+
+	return playlist_settings.current_position;
 }
 
 #include "moc_playlist.cpp"

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -314,6 +314,17 @@ protected:
 	void createToolbar();
 	void resort();
 
+	/**
+	 * Save playlist position if current playlist file is unmodified
+	 */
+	void savePosition();
+
+
+	/**
+	 * Load playlist position for current playlist file
+	 */
+	int loadPosition();
+
 protected:
 	void retranslateStrings();
 	virtual void changeEvent ( QEvent * event ) ;


### PR DESCRIPTION
#1353
Implements the following features:
- When a playlist changes track number, and has no unsaved modification,  the current track is written in a separate config file located in `config_path/playlist_per_file.ini`. It is associated to the hash of the playlist file.
- When a playlist is opened, the current track is set from the saved config if it exists.

Also changes the behavior of `Playlist::clear` to set the `modified` attribute, since it changes the playlist without saving

Only downside is that this feature is a bit redundant to the fact that it already saves  the parameters of the playlist to restore it after closing.