### PR TITLE
Force xcb backend even if QT_QPA_PLATFORM is already set

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,7 @@ int main( int argc, char ** argv )
 {
 #ifdef Q_OS_LINUX
 	#if QT_VERSION >= 0x050600
-	if (qgetenv("QT_QPA_PLATFORM").isEmpty()) {
-		qputenv("QT_QPA_PLATFORM", QByteArray("xcb"));
-	}
+	qputenv("QT_QPA_PLATFORM", QByteArray("xcb"));
 	#endif
 #endif
 


### PR DESCRIPTION
This ensures that always the `xcb` backend is used.

This fixes the video playback on systems where QT_QPA_PLATFORM is set to `wayland` globally.