### PR TITLE
Fix untranslated volume OSD with mpv

### DIFF
--- a/src/mpvoptions.cpp
+++ b/src/mpvoptions.cpp
@@ -832,7 +832,7 @@ void MPVProcess::quit() {
 }
 
 void MPVProcess::setVolume(int v) {
-	sendCommand("set volume " + QString::number(v));
+	sendCommand("no-osd set volume " + QString::number(v));
 }
 
 void MPVProcess::setOSD(int o) {


### PR DESCRIPTION
## Summary

- Suppress mpv's built-in OSD when changing the volume.
- Keep SMPlayer's translated volume message as the user-facing message.

mpv displays its own English volume OSD for the `set volume` command. SMPlayer already displays the translated `Volume: %1` message, so the `no-osd` prefix prevents the untranslated duplicate.

## Testing

- Built SMPlayer successfully on Windows with Qt 5.15.2 and MinGW 8.1 (64-bit).
- Opened a test video and ran the `increase_volume` action.
- Confirmed SMPlayer sent `no-osd set volume 54` to mpv and exited normally.

Fixes #262