### PR TITLE
Add configurable playback speed step

### DIFF
--- a/src/basegui.cpp
+++ b/src/basegui.cpp
@@ -590,13 +590,13 @@ void BaseGui::createActions() {
 	connect( doubleSpeedAct, SIGNAL(triggered()),
              core, SLOT(doubleSpeed()) );
 
-	decSpeed10Act = new MyAction( Qt::Key_BracketLeft, this, "dec_speed" );
-	connect( decSpeed10Act, SIGNAL(triggered()),
-             core, SLOT(decSpeed10()) );
+	decSpeedAct = new MyAction( Qt::Key_BracketLeft, this, "dec_speed" );
+	connect( decSpeedAct, SIGNAL(triggered()),
+             core, SLOT(decSpeed()) );
 
-	incSpeed10Act = new MyAction( Qt::Key_BracketRight, this, "inc_speed" );
-	connect( incSpeed10Act, SIGNAL(triggered()),
-             core, SLOT(incSpeed10()) );
+	incSpeedAct = new MyAction( Qt::Key_BracketRight, this, "inc_speed" );
+	connect( incSpeedAct, SIGNAL(triggered()),
+             core, SLOT(incSpeed()) );
 
 	decSpeed4Act = new MyAction( this, "dec_speed_4" );
 	connect( decSpeed4Act, SIGNAL(triggered()),
@@ -1419,8 +1419,8 @@ void BaseGui::setActionsEnabled(bool b) {
 	normalSpeedAct->setEnabled(b);
 	halveSpeedAct->setEnabled(b);
 	doubleSpeedAct->setEnabled(b);
-	decSpeed10Act->setEnabled(b);
-	incSpeed10Act->setEnabled(b);
+	decSpeedAct->setEnabled(b);
+	incSpeedAct->setEnabled(b);
 	decSpeed4Act->setEnabled(b);
 	incSpeed4Act->setEnabled(b);
 	decSpeed1Act->setEnabled(b);
@@ -1785,8 +1785,8 @@ void BaseGui::retranslateStrings() {
 	normalSpeedAct->change( tr("&Normal speed") );
 	halveSpeedAct->change( tr("&Half speed") );
 	doubleSpeedAct->change( tr("&Double speed") );
-	decSpeed10Act->change( tr("Speed &-10%") );
-	incSpeed10Act->change( tr("Speed &+10%") );
+	decSpeedAct->change( tr("&Decrease speed") );
+	incSpeedAct->change( tr("&Increase speed") );
 	decSpeed4Act->change( tr("Speed -&4%") );
 	incSpeed4Act->change( tr("&Speed +4%") );
 	decSpeed1Act->change( tr("Speed -&1%") );
@@ -2618,8 +2618,8 @@ void BaseGui::createMenus() {
 	speed_menu->addAction(halveSpeedAct);
 	speed_menu->addAction(doubleSpeedAct);
 	speed_menu->addSeparator();
-	speed_menu->addAction(decSpeed10Act);
-	speed_menu->addAction(incSpeed10Act);
+	speed_menu->addAction(decSpeedAct);
+	speed_menu->addAction(incSpeedAct);
 	speed_menu->addSeparator();
 	speed_menu->addAction(decSpeed4Act);
 	speed_menu->addAction(incSpeed4Act);

--- a/src/basegui.h
+++ b/src/basegui.h
@@ -493,8 +493,8 @@ protected:
 	MyAction * normalSpeedAct;
 	MyAction * halveSpeedAct;
 	MyAction * doubleSpeedAct;
-	MyAction * decSpeed10Act;
-	MyAction * incSpeed10Act;
+	MyAction * decSpeedAct;
+	MyAction * incSpeedAct;
 	MyAction * decSpeed4Act;
 	MyAction * incSpeed4Act;
 	MyAction * decSpeed1Act;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2842,7 +2842,7 @@ void Core::wheelUp() {
 		case Preferences::Volume : incVolume(); break;
 		case Preferences::Zoom : incZoom(); break;
 		case Preferences::Seeking : pref->wheel_function_seeking_reverse ? rewind( pref->seeking4 ) : forward( pref->seeking4 ); break;
-		case Preferences::ChangeSpeed : incSpeed10(); break;
+		case Preferences::ChangeSpeed : incSpeed(); break;
 		default : {} // do nothing
 	}
 }
@@ -2853,7 +2853,7 @@ void Core::wheelDown() {
 		case Preferences::Volume : decVolume(); break;
 		case Preferences::Zoom : decZoom(); break;
 		case Preferences::Seeking : pref->wheel_function_seeking_reverse ? forward( pref->seeking4 ) : rewind( pref->seeking4 ); break;
-		case Preferences::ChangeSpeed : decSpeed10(); break;
+		case Preferences::ChangeSpeed : decSpeed(); break;
 		default : {} // do nothing
 	}
 }
@@ -3386,16 +3386,16 @@ void Core::setSpeed( double value ) {
 	displayMessage( tr("Speed: %1").arg(value) );
 }
 
-void Core::incSpeed10() {
-	qDebug("Core::incSpeed10");
+void Core::incSpeed() {
+	qDebug("Core::incSpeed");
 	double speed = pref->global_speed ? pref->speed : mset.speed;
-	setSpeed( (double) speed + 0.1 );
+	setSpeed( (double) speed + pref->speed_step );
 }
 
-void Core::decSpeed10() {
-	qDebug("Core::decSpeed10");
+void Core::decSpeed() {
+	qDebug("Core::decSpeed");
 	double speed = pref->global_speed ? pref->speed : mset.speed;
-	setSpeed( (double) speed - 0.1 );
+	setSpeed( (double) speed - pref->speed_step );
 }
 
 void Core::incSpeed4() {

--- a/src/core.h
+++ b/src/core.h
@@ -211,8 +211,8 @@ public slots:
 	void wheelDown();
 
 	void setSpeed( double value );
-	void incSpeed10();	//!< Inc speed 10%
-	void decSpeed10();	//!< Dec speed 10%
+	void incSpeed();
+	void decSpeed();
 	void incSpeed4();	//!< Inc speed 4%
 	void decSpeed4();	//!< Dec speed 4%
 	void incSpeed1();	//!< Inc speed 1%

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -182,6 +182,7 @@ void Preferences::reset() {
 
 	global_speed = false;
 	speed = 1.0;
+	speed_step = 0.1;
 
 	autosync = false;
 	autosync_factor = 100;
@@ -764,6 +765,7 @@ void Preferences::save() {
 
 	set->setValue("global_speed", global_speed);
 	set->setValue("speed", speed);
+	set->setValue("speed_step", speed_step);
 
 	set->setValue("autosync", autosync);
 	set->setValue("autosync_factor", autosync_factor);
@@ -1365,6 +1367,7 @@ void Preferences::load() {
 
 	global_speed = set->value("global_speed", global_speed).toBool();
 	speed = set->value("speed", speed).toDouble();
+	speed_step = set->value("speed_step", speed_step).toDouble();
 
 	autosync = set->value("autosync", autosync).toBool();
 	autosync_factor = set->value("autosync_factor", autosync_factor).toInt();

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -150,9 +150,10 @@ public:
 	bool global_audio_equalizer;
 	AudioEqualizerList audio_equalizer;
 
-	// Global speed
+	// Playback speed
 	bool global_speed;
 	double speed;
+	double speed_step;
 
 	bool autosync;
 	int autosync_factor;

--- a/src/prefgeneral.cpp
+++ b/src/prefgeneral.cpp
@@ -339,6 +339,7 @@ void PrefGeneral::setData(Preferences * pref) {
 #endif // AUDIO_DEVICES_SELECTION
 
 	global_speed_check->setChecked(pref->global_speed);
+	speed_step_spin->setValue(pref->speed_step);
 }
 
 void PrefGeneral::getData(Preferences * pref) {
@@ -465,6 +466,7 @@ void PrefGeneral::getData(Preferences * pref) {
 	TEST_AND_SET(pref->mc_value, mc());
 
 	pref->global_speed = global_speed_check->isChecked();
+	pref->speed_step = speed_step_spin->value();
 }
 
 void PrefGeneral::updateDriverCombos() {
@@ -1134,6 +1136,10 @@ void PrefGeneral::createHelp() {
 	setWhatsThis(global_speed_check, tr("Keep selected speed across files"),
 		tr("If this option is enabled, the speed selected in the Play menu will be applied for all files.") +" "+
 		tr("Otherwise each file will use its own speed setting."));
+
+	setWhatsThis(speed_step_spin, tr("Playback speed step"),
+		tr("Specifies how much the playback speed changes when using the increase speed or decrease speed actions.") + " " +
+		tr("For example, a step of 0.25 changes 1.00x speed to 1.25x or 0.75x."));
 
 	setWhatsThis(pause_if_hidden_check, tr("Pause when minimized"),
 		tr("If this option is enabled, the file will be paused when the "

--- a/src/prefgeneral.ui
+++ b/src/prefgeneral.ui
@@ -271,6 +271,55 @@
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="speed_step_layout">
+         <item>
+          <widget class="QLabel" name="speed_step_label">
+           <property name="text">
+            <string>Playback speed s&amp;tep:</string>
+           </property>
+           <property name="buddy">
+            <cstring>speed_step_spin</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="speed_step_spin">
+           <property name="suffix">
+            <string notr="true">x</string>
+           </property>
+           <property name="decimals">
+            <number>2</number>
+           </property>
+           <property name="minimum">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="speed_step_spacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QCheckBox" name="pause_if_hidden_check">
          <property name="text">
           <string>&amp;Pause when minimized</string>
@@ -1362,6 +1411,7 @@ For translators: don't translate this text, it will be replaced with another one
   <tabstop>screenshot_template_edit</tabstop>
   <tabstop>screenshot_format_combo</tabstop>
   <tabstop>global_speed_check</tabstop>
+  <tabstop>speed_step_spin</tabstop>
   <tabstop>pause_if_hidden_check</tabstop>
   <tabstop>close_on_finish_check</tabstop>
   <tabstop>shutdown_check</tabstop>


### PR DESCRIPTION
## Summary

- add a configurable playback speed step to the General preferences, defaulting to the existing 0.10x increment
- apply the configured value to the existing `inc_speed` and `dec_speed` actions, including keyboard and mouse-wheel controls
- keep the existing action IDs and fixed 4% and 1% speed actions for compatibility

## Testing

- built the release target on Windows with Qt 5.15.2 and MinGW 8.1
- verified the command-line help smoke test
- manually verified changing the setting and adjusting speed during playback with the keyboard and mouse wheel
- manually verified remembered playback speed when opening other files
- ran `git diff --check`

Closes #1387