### PR TITLE
Use cdda-device for mpv audio CDs

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2159,7 +2159,14 @@ void Core::startMplayer( QString file, double seek ) {
 
 	if ((mdat.type==TYPE_VCD) || (mdat.type==TYPE_AUDIO_CD)) {
 		if (!pref->cdrom_device.isEmpty()) {
-			proc->setOption("cdrom-device", pref->cdrom_device);
+			#ifdef MPV_SUPPORT
+			if (proc->isMPV() && mdat.type == TYPE_AUDIO_CD) {
+				proc->setOption("cdda-device", pref->cdrom_device);
+			} else
+			#endif
+			{
+				proc->setOption("cdrom-device", pref->cdrom_device);
+			}
 		}
 	}
 

--- a/src/mpvoptions.cpp
+++ b/src/mpvoptions.cpp
@@ -652,7 +652,7 @@ void MPVProcess::setOption(const QString & option_name, const QVariant & value) 
 	    option_name == "priority" ||
 	    option_name == "hwdec" ||
 	    option_name == "autosync" ||
-	    option_name == "dvd-device" || option_name == "cdrom-device" ||
+	    option_name == "dvd-device" || option_name == "cdrom-device" || option_name == "cdda-device" ||
 	    option_name == "demuxer" ||
 	    option_name == "frames" ||
 	    option_name == "user-agent" || option_name == "referrer" || option_name == "http-header-fields" ||


### PR DESCRIPTION
## Summary

- use mpv's `cdda-device` option when opening audio CDs
- preserve `cdrom-device` for the MPlayer backend and VCD playback
- recognize `cdda-device` in SMPlayer's mpv option handling

## Testing

- Full Windows release build
- Physical audio CD playback was not available for hardware validation

Fixes #1379