### PR TITLE
Avoid fullscreen for audio files with cover art

### DIFF
--- a/src/basegui.cpp
+++ b/src/basegui.cpp
@@ -5392,7 +5392,9 @@ void BaseGui::enterFullscreenOnPlay() {
 	qDebug("BaseGui::enterFullscreenOnPlay: arg_start_in_fullscreen: %d, pref->start_in_fullscreen: %d", arg_start_in_fullscreen, pref->start_in_fullscreen);
 
 	if (arg_start_in_fullscreen != 0) {
-		if ((arg_start_in_fullscreen == 1 || pref->start_in_fullscreen) && !core->mdat.novideo) {
+		if ((arg_start_in_fullscreen == 1 || pref->start_in_fullscreen) &&
+		    !core->mdat.novideo && !core->mdat.video_is_album_art)
+		{
 			if (!pref->fullscreen) toggleFullscreen(true);
 		}
 	}

--- a/src/mediadata.cpp
+++ b/src/mediadata.cpp
@@ -37,6 +37,7 @@ void MediaData::reset() {
 	extra_params.clear();
 
 	novideo = false;
+	video_is_album_art = false;
 
 	video_width=0;
 	video_height=0;
@@ -115,6 +116,7 @@ void MediaData::list() {
 
 	qDebug("  type: %d", type);
 	qDebug("  novideo: %d", novideo);
+	qDebug("  video_is_album_art: %d", video_is_album_art);
 	qDebug("  dvd_id: '%s'", dvd_id.toUtf8().data());
 
 	qDebug("  initialized: %d", initialized);

--- a/src/mediadata.h
+++ b/src/mediadata.h
@@ -69,6 +69,7 @@ public:
 	QString dvd_id;
 
 	bool novideo; // Only audio
+	bool video_is_album_art; // The selected video track is audio cover art
 
 	bool initialized;
 

--- a/src/mpvprocess.cpp
+++ b/src/mpvprocess.cpp
@@ -204,6 +204,7 @@ void MPVProcess::parseLine(QByteArray ba) {
                                       << "current-vo" << "current-ao"
                                       << "width" << "height" //<< "dwidth" << "dheight"
                                       << "video-params/aspect"
+                                      << "current-tracks/video/albumart"
                                       << "track-list/0/demux-rotation"
                                       << "container-fps" << "video-format"
                                       << "audio-codec-name" << "audio-params/samplerate" << "audio-params/channel-count"
@@ -458,6 +459,10 @@ void MPVProcess::socketReadyRead() {
 			else
 			if (name == "video-params/aspect") {
 				md.video_aspect = data.toDouble();
+			}
+			else
+			if (name == "current-tracks/video/albumart") {
+				md.video_is_album_art = data == "true";
 			}
 			else
 			if (name == "container-fps") {


### PR DESCRIPTION
## Summary

- observe whether mpv's selected video track is album art
- retain that state in media metadata
- skip automatic fullscreen for audio cover art while preserving fullscreen for ordinary video

## Testing

- Full Windows release build
- Runtime test with an MP3 containing embedded cover art and automatic fullscreen enabled: no fullscreen toggle
- Control runtime test with an ordinary video: fullscreen toggle still occurred

Fixes #1384